### PR TITLE
feat: add configurable API model IDs for DeepSeek V4 Flash and Pro models

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,6 +116,16 @@
           "minimum": 0,
           "description": "Maximum number of output tokens per request. Set to 0 to use the API default (no limit). Useful for controlling costs."
         },
+        "deepseek-copilot.flashModelId": {
+          "type": "string",
+          "default": "deepseek-v4-flash",
+          "description": "API model ID sent to the DeepSeek endpoint for the DeepSeek V4 Flash model. Change this when using a compatible third-party API that uses a different model name."
+        },
+        "deepseek-copilot.proModelId": {
+          "type": "string",
+          "default": "deepseek-v4-pro",
+          "description": "API model ID sent to the DeepSeek endpoint for the DeepSeek V4 Pro model. Change this when using a compatible third-party API that uses a different model name."
+        },
         "deepseek-copilot.visionModel": {
           "type": "string",
           "default": "",

--- a/package.json
+++ b/package.json
@@ -116,15 +116,24 @@
           "minimum": 0,
           "description": "Maximum number of output tokens per request. Set to 0 to use the API default (no limit). Useful for controlling costs."
         },
-        "deepseek-copilot.flashModelId": {
-          "type": "string",
-          "default": "deepseek-v4-flash",
-          "description": "API model ID sent to the DeepSeek endpoint for the DeepSeek V4 Flash model. Change this when using a compatible third-party API that uses a different model name."
-        },
-        "deepseek-copilot.proModelId": {
-          "type": "string",
-          "default": "deepseek-v4-pro",
-          "description": "API model ID sent to the DeepSeek endpoint for the DeepSeek V4 Pro model. Change this when using a compatible third-party API that uses a different model name."
+        "deepseek-copilot.modelIdOverrides": {
+          "type": "object",
+          "default": {
+            "deepseek-v4-flash": "deepseek-v4-flash",
+            "deepseek-v4-pro": "deepseek-v4-pro"
+          },
+          "description": "Override the API model ID sent for each DeepSeek model. Defaults are prefilled with official DeepSeek IDs; change them only when using a compatible third-party API that uses different model names.",
+          "additionalProperties": false,
+          "properties": {
+            "deepseek-v4-flash": {
+              "type": "string",
+              "description": "API model ID for DeepSeek V4 Flash"
+            },
+            "deepseek-v4-pro": {
+              "type": "string",
+              "description": "API model ID for DeepSeek V4 Pro"
+            }
+          }
         },
         "deepseek-copilot.visionModel": {
           "type": "string",

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -91,6 +91,21 @@ export class AuthManager {
 	}
 
 	/**
+	 * Resolve the API model ID to send to the DeepSeek endpoint.
+	 * Users can override the default IDs via settings to support compatible APIs.
+	 */
+	getApiModelId(vscodeModelId: string): string {
+		const config = vscode.workspace.getConfiguration('deepseek-copilot');
+		if (vscodeModelId === 'deepseek-v4-flash') {
+			return config.get<string>('flashModelId')?.trim() || 'deepseek-v4-flash';
+		}
+		if (vscodeModelId === 'deepseek-v4-pro') {
+			return config.get<string>('proModelId')?.trim() || 'deepseek-v4-pro';
+		}
+		return vscodeModelId;
+	}
+
+	/**
 	 * Get max tokens limit (0 = no limit).
 	 */
 	getMaxTokens(): number | undefined {

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -96,13 +96,9 @@ export class AuthManager {
 	 */
 	getApiModelId(vscodeModelId: string): string {
 		const config = vscode.workspace.getConfiguration('deepseek-copilot');
-		if (vscodeModelId === 'deepseek-v4-flash') {
-			return config.get<string>('flashModelId')?.trim() || 'deepseek-v4-flash';
-		}
-		if (vscodeModelId === 'deepseek-v4-pro') {
-			return config.get<string>('proModelId')?.trim() || 'deepseek-v4-pro';
-		}
-		return vscodeModelId;
+		const overrides = config.get<Record<string, string>>('modelIdOverrides');
+		const override = overrides?.[vscodeModelId]?.trim();
+		return override || vscodeModelId;
 	}
 
 	/**

--- a/src/provider/index.ts
+++ b/src/provider/index.ts
@@ -231,7 +231,7 @@ export class DeepSeekChatProvider implements vscode.LanguageModelChatProvider {
 		return new Promise<void>((resolve, reject) => {
 			client.streamChatCompletion(
 				{
-					model: modelInfo.id,
+					model: this.authManager.getApiModelId(modelInfo.id),
 					messages: deepseekMessages,
 					stream: true,
 					tools,


### PR DESCRIPTION
This pull request adds support for overriding the API model IDs sent to the DeepSeek endpoint, allowing users to specify custom model IDs for compatible third-party APIs. The main changes include a new configuration option, logic to resolve the correct model ID, and updating the chat provider to use this logic.

**Configuration and Model ID Overrides:**
- Added a new configuration option `deepseek-copilot.modelIdOverrides` in `package.json`, allowing users to override the default API model IDs for DeepSeek models. This is useful for users of compatible third-party APIs with different model naming conventions.

**Core Logic Updates:**
- Implemented a new `getApiModelId` method in the `AuthManager` class (`src/auth.ts`) to resolve the correct model ID, using the override if provided, or falling back to the default.

**Provider Integration:**
- Updated the `DeepSeekChatProvider` (`src/provider/index.ts`) to use the new `getApiModelId` method when sending chat completion requests, ensuring the correct model ID is always used.