### PR TITLE
feat: 国际化中文适配 + 上下文用量状态栏

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,39 +51,43 @@
     "commands": [
       {
         "command": "deepseek-copilot.setApiKey",
-        "title": "DeepSeek: Set API Key"
+        "title": "%deepseek-copilot.command.setApiKey%"
       },
       {
         "command": "deepseek-copilot.getApiKey",
-        "title": "DeepSeek: Get API Key"
+        "title": "%deepseek-copilot.command.getApiKey%"
       },
       {
         "command": "deepseek-copilot.clearApiKey",
-        "title": "DeepSeek: Clear API Key"
+        "title": "%deepseek-copilot.command.clearApiKey%"
       },
       {
         "command": "deepseek-copilot.setVisionModel",
-        "title": "DeepSeek: Set Vision Proxy Model"
+        "title": "%deepseek-copilot.command.setVisionModel%"
       },
       {
         "command": "deepseek-copilot.openSettings",
-        "title": "DeepSeek: Open Settings"
+        "title": "%deepseek-copilot.command.openSettings%"
       },
       {
         "command": "deepseek-copilot.showLogs",
-        "title": "DeepSeek: Show Logs"
+        "title": "%deepseek-copilot.command.showLogs%"
+      },
+      {
+        "command": "deepseek-copilot.showContextDetails",
+        "title": "%deepseek-copilot.command.showContextDetails%"
       }
     ],
     "walkthroughs": [
       {
         "id": "deepseekGettingStarted",
-        "title": "DeepSeek V4 for Copilot Chat",
-        "description": "Set up DeepSeek V4 models in Copilot Chat.",
+        "title": "%deepseek-copilot.walkthrough.title%",
+        "description": "%deepseek-copilot.walkthrough.description%",
         "steps": [
           {
             "id": "setApiKey",
-            "title": "Set your DeepSeek API key",
-            "description": "[Get an API key](command:deepseek-copilot.getApiKey) from deepseek.com.\n[Set API Key](command:deepseek-copilot.setApiKey)",
+            "title": "%deepseek-copilot.walkthrough.setApiKey.title%",
+            "description": "%deepseek-copilot.walkthrough.setApiKey.description%",
             "media": {
               "markdown": "resources/walkthrough/set-api-key.md"
             },
@@ -93,8 +97,8 @@
           },
           {
             "id": "showModels",
-            "title": "Show DeepSeek models",
-            "description": "If the models are hidden, open VS Code's Language Models manager and show the DeepSeek models.\n[Open Language Models](command:workbench.action.chat.manage)",
+            "title": "%deepseek-copilot.walkthrough.showModels.title%",
+            "description": "%deepseek-copilot.walkthrough.showModels.description%",
             "media": {
               "markdown": "resources/walkthrough/show-models.md"
             }
@@ -103,29 +107,29 @@
       }
     ],
     "configuration": {
-      "title": "DeepSeek Copilot",
+      "title": "%deepseek-copilot.config.title%",
       "properties": {
         "deepseek-copilot.baseUrl": {
           "type": "string",
           "default": "https://api.deepseek.com",
-          "description": "DeepSeek API base URL. Defaults to official DeepSeek API endpoint."
+          "description": "%deepseek-copilot.config.baseUrl.description%"
         },
         "deepseek-copilot.maxTokens": {
           "type": "number",
           "default": 0,
           "minimum": 0,
-          "description": "Maximum number of output tokens per request. Set to 0 to use the API default (no limit). Useful for controlling costs."
+          "description": "%deepseek-copilot.config.maxTokens.description%"
         },
         "deepseek-copilot.visionModel": {
           "type": "string",
           "default": "",
-          "description": "Model ID for vision proxy (describes images for text-only DeepSeek models). Leave empty for auto-detection. Use 'DeepSeek: Set Vision Proxy Model' command to pick one from a list."
+          "description": "%deepseek-copilot.config.visionModel.description%"
         },
         "deepseek-copilot.visionPrompt": {
           "type": "string",
           "editPresentation": "multilineText",
           "default": "Describe the visual contents of this image in detail, including any text, objects, people, or context that would be relevant for understanding it. Focus on factual visual elements.",
-          "description": "Prompt sent to the vision proxy model when describing image attachments before forwarding them to DeepSeek."
+          "description": "%deepseek-copilot.config.visionPrompt.description%"
         }
       }
     }

--- a/package.nls.json
+++ b/package.nls.json
@@ -1,0 +1,20 @@
+{
+  "deepseek-copilot.command.setApiKey": "DeepSeek: Set API Key",
+  "deepseek-copilot.command.getApiKey": "DeepSeek: Get API Key",
+  "deepseek-copilot.command.clearApiKey": "DeepSeek: Clear API Key",
+  "deepseek-copilot.command.setVisionModel": "DeepSeek: Set Vision Proxy Model",
+  "deepseek-copilot.command.openSettings": "DeepSeek: Open Settings",
+  "deepseek-copilot.command.showLogs": "DeepSeek: Show Logs",
+  "deepseek-copilot.command.showContextDetails": "DeepSeek: Show Context Details",
+  "deepseek-copilot.walkthrough.title": "DeepSeek V4 for Copilot Chat",
+  "deepseek-copilot.walkthrough.description": "Set up DeepSeek V4 models in Copilot Chat.",
+  "deepseek-copilot.walkthrough.setApiKey.title": "Set your DeepSeek API key",
+  "deepseek-copilot.walkthrough.setApiKey.description": "[Get an API key](command:deepseek-copilot.getApiKey) from deepseek.com.\n[Set API Key](command:deepseek-copilot.setApiKey)",
+  "deepseek-copilot.walkthrough.showModels.title": "Show DeepSeek models",
+  "deepseek-copilot.walkthrough.showModels.description": "If the models are hidden, open VS Code's Language Models manager and show the DeepSeek models.\n[Open Language Models](command:workbench.action.chat.manage)",
+  "deepseek-copilot.config.title": "DeepSeek Copilot",
+  "deepseek-copilot.config.baseUrl.description": "DeepSeek API base URL. Defaults to official DeepSeek API endpoint.",
+  "deepseek-copilot.config.maxTokens.description": "Maximum number of output tokens per request. Set to 0 to use the API default (no limit). Useful for controlling costs.",
+  "deepseek-copilot.config.visionModel.description": "Model ID for vision proxy (describes images for text-only DeepSeek models). Leave empty for auto-detection. Use 'DeepSeek: Set Vision Proxy Model' command to pick one from a list.",
+  "deepseek-copilot.config.visionPrompt.description": "Prompt sent to the vision proxy model when describing image attachments before forwarding them to DeepSeek."
+}

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -1,0 +1,20 @@
+{
+  "deepseek-copilot.command.setApiKey": "DeepSeek: 设置 API Key",
+  "deepseek-copilot.command.getApiKey": "DeepSeek: 获取 API Key",
+  "deepseek-copilot.command.clearApiKey": "DeepSeek: 清除 API Key",
+  "deepseek-copilot.command.setVisionModel": "DeepSeek: 设置视觉代理模型",
+  "deepseek-copilot.command.openSettings": "DeepSeek: 打开设置",
+  "deepseek-copilot.command.showLogs": "DeepSeek: 显示日志",
+  "deepseek-copilot.command.showContextDetails": "DeepSeek: 显示上下文详情",
+  "deepseek-copilot.walkthrough.title": "DeepSeek V4 for Copilot Chat",
+  "deepseek-copilot.walkthrough.description": "在 Copilot Chat 中配置 DeepSeek V4 模型。",
+  "deepseek-copilot.walkthrough.setApiKey.title": "设置你的 DeepSeek API Key",
+  "deepseek-copilot.walkthrough.setApiKey.description": "从 deepseek.com [获取 API Key](command:deepseek-copilot.getApiKey)。\n[设置 API Key](command:deepseek-copilot.setApiKey)",
+  "deepseek-copilot.walkthrough.showModels.title": "显示 DeepSeek 模型",
+  "deepseek-copilot.walkthrough.showModels.description": "如果模型被隐藏，打开 VS Code 的语言模型管理器并显示 DeepSeek 模型。\n[打开语言模型管理](command:workbench.action.chat.manage)",
+  "deepseek-copilot.config.title": "DeepSeek 助手",
+  "deepseek-copilot.config.baseUrl.description": "DeepSeek API 基础 URL。默认为官方 DeepSeek API 端点。",
+  "deepseek-copilot.config.maxTokens.description": "每次请求的最大输出 Token 数。设为 0 使用 API 默认值（不限制）。可用于控制成本。",
+  "deepseek-copilot.config.visionModel.description": "视觉代理模型 ID（为纯文本 DeepSeek 模型描述图片）。留空自动检测。使用「DeepSeek: 设置视觉代理模型」命令从列表中选择。",
+  "deepseek-copilot.config.visionPrompt.description": "在将图片附件转发给 DeepSeek 之前，发送给视觉代理模型的提示词。"
+}

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { t } from './i18n';
 
 const API_KEY_SECRET = 'deepseek-copilot.apiKey';
 
@@ -58,16 +59,16 @@ export class AuthManager {
 	 */
 	async promptForApiKey(): Promise<boolean> {
 		const apiKey = await vscode.window.showInputBox({
-			prompt: 'Enter your DeepSeek API key',
-			placeHolder: 'sk-...',
+			prompt: t('auth.prompt'),
+			placeHolder: t('auth.placeholder'),
 			password: true,
 			ignoreFocusOut: true,
 			validateInput: (value: string) => {
 				if (!value?.trim()) {
-					return 'API key cannot be empty';
+					return t('auth.emptyValidation');
 				}
 				if (!value.startsWith('sk-')) {
-					return 'API key should start with "sk-"';
+					return t('auth.prefixValidation');
 				}
 				return undefined;
 			},
@@ -75,7 +76,7 @@ export class AuthManager {
 
 		if (apiKey) {
 			await this.setApiKey(apiKey);
-			vscode.window.showInformationMessage('DeepSeek API key saved securely.');
+			vscode.window.showInformationMessage(t('auth.saved'));
 			return true;
 		}
 

--- a/src/context-display.ts
+++ b/src/context-display.ts
@@ -1,0 +1,171 @@
+import * as vscode from 'vscode';
+import { t } from './i18n';
+
+/**
+ * 上下文显示 —— 类似 Copilot 的状态栏上下文指示器。
+ *
+ * 状态栏：`$(chip) V4 Pro ▓▓▓░░ 45%`（5段进度条 + 百分比）
+ * Tooltip：完整用量面板含10段进度条
+ * 会话持久化：关闭 VS Code 重开自动恢复上次用量
+ */
+
+const STATE_KEY = 'deepseek-copilot.contextState';
+
+/** 1M 上下文窗口 */
+const CTX_MAX = 1_048_576;
+
+/** 状态栏进度条段数（紧凑） */
+const BAR_SM = 5;
+
+/** Tooltip / 详细面板进度条段数 */
+const BAR_LG = 10;
+
+export interface UsageSnapshot {
+	promptTokens: number;
+	completionTokens: number;
+	totalTokens: number;
+	cacheHitTokens: number;
+	cacheMissTokens: number;
+	charsPerToken: number;
+}
+
+export interface ContextState {
+	lastModelId: string;
+	lastThinkingEffort: string;
+	lastUsage: UsageSnapshot | null;
+}
+
+// ---- 工具函数 ----
+
+function fmtNum(n: number): string {
+	if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + 'M';
+	if (n >= 1_000) return (n / 1_000).toFixed(1) + 'K';
+	return String(n);
+}
+
+function fmtPct(hit: number, miss: number): string {
+	const t = hit + miss;
+	return t > 0 ? ((hit / t) * 100).toFixed(0) + '%' : '—';
+}
+
+/** 进度条：█（实心）+ ░（空） */
+function bar(used: number, max: number, segs: number): string {
+	const f = Math.round(Math.min(used / max, 1) * segs);
+	return '█'.repeat(f) + '░'.repeat(segs - f);
+}
+
+export class ContextDisplay {
+	private readonly item: vscode.StatusBarItem;
+	private readonly store: vscode.Memento;
+	private state: ContextState = {
+		lastModelId: 'deepseek',
+		lastThinkingEffort: 'high',
+		lastUsage: null,
+	};
+
+	constructor(context: vscode.ExtensionContext) {
+		this.store = context.globalState;
+		context.subscriptions.push(this);
+
+		this.item = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 99);
+		this.item.name = 'DeepSeek Context';
+		// 点击状态栏 → 打开 DeepSeek 输出日志
+		this.item.command = 'deepseek-copilot.showLogs';
+
+		this.restore();
+	}
+
+	dispose(): void {
+		this.save();
+		this.item.dispose();
+	}
+
+	/** 新 API 用量数据到来 */
+	update(modelId: string, thinkingEffort: string, usage: UsageSnapshot): void {
+		this.state = { lastModelId: modelId, lastThinkingEffort: thinkingEffort, lastUsage: usage };
+		this.save();
+		this.refresh();
+	}
+
+	// ---- 持久化 ----
+
+	private save(): void {
+		try { void this.store.update(STATE_KEY, this.state); } catch { /* noop */ }
+	}
+
+	private restore(): void {
+		try {
+			const s = this.store.get<ContextState>(STATE_KEY);
+			if (s?.lastUsage) this.state = s;
+		} catch { /* noop */ }
+		this.refresh();
+	}
+
+	// ---- 渲染 ----
+
+	private refresh(): void {
+		const u = this.state.lastUsage;
+		const name = alias(this.state.lastModelId);
+
+		if (!u) {
+			this.item.text = `$(chip) ${name}`;
+			this.item.tooltip = t('status.noData');
+			this.item.show();
+			return;
+		}
+
+		const ratio = Math.min(u.promptTokens / CTX_MAX, 1);
+		const pct = Math.round(ratio * 100);
+		const compactBar = bar(u.promptTokens, CTX_MAX, BAR_SM);
+
+		this.item.text = `$(chip) ${name} ${compactBar} ${pct}%`;
+		this.item.tooltip = this.buildTooltip();
+		this.item.show();
+	}
+
+	private buildTooltip(): vscode.MarkdownString {
+		const u = this.state.lastUsage!;
+		const ratio = Math.min(u.promptTokens / CTX_MAX, 1);
+		const pct = Math.round(ratio * 100);
+		// 纯 █ / ░，不用 code fence
+		const fullBar = '█'.repeat(Math.round(ratio * BAR_LG)) + '░'.repeat(Math.max(0, BAR_LG - Math.round(ratio * BAR_LG)));
+
+		const md = new vscode.MarkdownString();
+		md.isTrusted = true;
+		md.supportHtml = false;
+
+		md.appendMarkdown(`**${alias(this.state.lastModelId)}** · *${thinkLabel(this.state.lastThinkingEffort)}*\n\n`);
+		// 进度条：加粗纯文本
+		md.appendMarkdown(`**${fullBar}  ${pct}%**\n\n`);
+		// 用量摘要
+		md.appendMarkdown(`*${fmtNum(u.promptTokens)} / ${fmtNum(CTX_MAX)}  ${t('status.promptTokens')}*\n\n`);
+
+		const kv = (k: string, v: string) => `- **${k}**: \`${v}\`  \n`;
+
+		md.appendMarkdown(kv(t('status.promptTokens'),     u.promptTokens.toLocaleString()));
+		md.appendMarkdown(kv(t('status.completionTokens'), u.completionTokens.toLocaleString()));
+		md.appendMarkdown(kv(t('status.totalTokens'),      u.totalTokens.toLocaleString()));
+		md.appendMarkdown(kv(t('status.cacheHit'),         u.cacheHitTokens.toLocaleString()));
+		md.appendMarkdown(kv(t('status.cacheMiss'),        u.cacheMissTokens.toLocaleString()));
+		md.appendMarkdown(kv(t('status.cacheRate'),        fmtPct(u.cacheHitTokens, u.cacheMissTokens)));
+		md.appendMarkdown(kv(t('status.charsPerToken'),    u.charsPerToken.toFixed(2)));
+
+		md.appendMarkdown(`\n---\n\n*${t('status.clickForDetail')}*`);
+		return md;
+	}
+
+}
+
+/** 模型简称 */
+function alias(id: string): string {
+	if (id === 'deepseek-v4-pro') return 'V4 Pro';
+	if (id === 'deepseek-v4-flash') return 'V4 Flash';
+	return id;
+}
+
+/** 思考模式标签 */
+function thinkLabel(effort: string): string {
+	if (effort === 'none') return t('thinking.none');
+	if (effort === 'max') return t('thinking.max');
+	return t('thinking.high');
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,6 @@
 import * as vscode from 'vscode';
+import { ContextDisplay, type UsageSnapshot } from './context-display';
+import { t } from './i18n';
 import { logger } from './logger';
 import { DeepSeekChatProvider } from './provider';
 
@@ -6,9 +8,12 @@ const WELCOME_SHOWN_KEY = 'deepseek-copilot.welcomeShown';
 const WALKTHROUGH_ID = 'Vizards.deepseek-v4-for-copilot#deepseekGettingStarted';
 
 let activeProvider: DeepSeekChatProvider | undefined;
+let contextDisplay: ContextDisplay | undefined;
 
 export function activate(context: vscode.ExtensionContext) {
 	logger.info('Activating extension');
+
+	contextDisplay = new ContextDisplay(context);
 
 	context.subscriptions.push(
 		vscode.commands.registerCommand('deepseek-copilot.showLogs', () => logger.show()),
@@ -18,10 +23,19 @@ export function activate(context: vscode.ExtensionContext) {
 		vscode.commands.registerCommand('deepseek-copilot.openSettings', () =>
 			vscode.commands.executeCommand('workbench.action.openSettings', 'deepseek-copilot'),
 		),
+		vscode.commands.registerCommand('deepseek-copilot.showContextDetails', () =>
+			logger.show(),
+		),
 	);
 
 	try {
 		const provider = new DeepSeekChatProvider(context);
+
+		// 将 API 用量数据传递给上下文显示器
+		provider.onUsageUpdate((modelId: string, thinkingEffort: string, usage: UsageSnapshot) => {
+			contextDisplay?.update(modelId, thinkingEffort, usage);
+		});
+
 		activeProvider = provider;
 
 		context.subscriptions.push(
@@ -38,16 +52,14 @@ export function activate(context: vscode.ExtensionContext) {
 		);
 
 		void showWelcomeIfNeeded(context, provider).catch((error) => {
-			logger.warn('Failed to show DeepSeek welcome prompt', error);
+			logger.warn(t('extension.welcomeFailed'), error);
 		});
 
 		logger.info('Extension activated');
 	} catch (error) {
 		activeProvider = undefined;
 		logger.error('Failed to activate DeepSeek extension', error);
-		void vscode.window.showErrorMessage(
-			'DeepSeek failed to activate. Run "DeepSeek: Show Logs" for details.',
-		);
+		void vscode.window.showErrorMessage(t('extension.activateFailed'));
 		throw error;
 	}
 }
@@ -76,8 +88,9 @@ export async function deactivate() {
 	try {
 		await activeProvider?.prepareForDeactivate();
 	} catch (error) {
-		logger.warn('Failed to prepare DeepSeek provider for deactivate', error);
+		logger.warn(t('extension.deactivateFailed'), error);
 	} finally {
+		contextDisplay = undefined;
 		activeProvider = undefined;
 		logger.info('Extension deactivated');
 		logger.dispose();

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,0 +1,154 @@
+import { env } from 'vscode';
+
+/**
+ * 轻量级国际化模块 —— 零外部依赖，跟随 VS Code 显示语言。
+ *
+ *  - en / en-US / en-* → 英文（默认）
+ *  - zh-cn / zh / zh-*   → 简体中文
+ */
+
+function isZh(): boolean {
+	const lang = env.language.toLowerCase();
+	return lang === 'zh-cn' || lang === 'zh' || lang.startsWith('zh-');
+}
+
+// ---- 翻译字典 ----
+
+type Translations = Record<string, string>;
+
+const zh: Translations = {
+	// 模型描述
+	'model.flash.detail': '快速高效',
+	'model.pro.detail': '深度推理',
+
+	// API Key
+	'auth.apiKeyRequired': '请先在命令面板运行 "DeepSeek: 设置 API Key" 配置密钥',
+	'auth.apiKeyRequiredDetail': '请先配置 API Key',
+	'auth.prompt': '请输入 DeepSeek API Key',
+	'auth.placeholder': 'sk-...',
+	'auth.emptyValidation': 'API Key 不能为空',
+	'auth.prefixValidation': 'API Key 应以 "sk-" 开头',
+	'auth.saved': 'API Key 已保存。',
+	'auth.removed': 'API Key 已移除。',
+	'auth.notConfigured': 'API Key 未配置，请在命令面板运行 "DeepSeek: 设置 API Key"',
+
+	// Thinking Effort —— 模型选择器下拉标签，保留简短
+	'thinking.none': '停用',
+	'thinking.none.desc': '停用思考，响应更快',
+	'thinking.high': '标准',
+	'thinking.high.desc': '推荐日常使用',
+	'thinking.max': '深度',
+	'thinking.max.desc': '深度推理，适合复杂任务',
+
+	// Vision
+	'vision.noModel': '当前环境中无可用的语言模型',
+	'vision.pickPlaceholder': '选择用于描述图片的模型（默认 {0}）',
+	'vision.current': '当前',
+	'vision.proxyUsing': '视觉代理：{0}',
+	'vision.notFound': '未找到视觉模型 "{0}"',
+	'vision.unavailable': '无可用视觉模型，图片已忽略',
+	'vision.proxyError': '视觉代理异常：',
+	'vision.unableToDescribe': '[图片无法识别]',
+
+	// Extension
+	'extension.activateFailed': 'DeepSeek 激活失败，请运行 "DeepSeek: 显示日志" 查看详情',
+	'extension.deactivateFailed': 'DeepSeek 停用异常',
+	'extension.welcomeFailed': '欢迎引导加载异常',
+
+	// Status bar / context display
+	'status.model': '模型',
+	'status.thinking': '思考',
+	'status.promptTokens': '输入 Token',
+	'status.completionTokens': '输出 Token',
+	'status.totalTokens': '合计 Token',
+	'status.cacheHit': '缓存命中',
+	'status.cacheMiss': '缓存未命中',
+	'status.cacheRate': '缓存命中率',
+	'status.charsPerToken': '字符/Token',
+	'status.noData': '等待首次 API 调用…',
+	'status.clickForDetail': '点击查看日志',
+
+	// Log output
+	'log.tokens': 'tokens: prompt={0} completion={1}',
+	'log.cache': 'cache: hit={0} miss={1} rate={2}%',
+	'log.charsPerToken': 'chars/tok={0}',
+};
+
+const en: Translations = {
+	// Model descriptions
+	'model.flash.detail': 'Fast, general-purpose model',
+	'model.pro.detail': 'Most capable reasoning model',
+
+	// API Key
+	'auth.apiKeyRequired': 'Please run "DeepSeek: Set API Key" to configure.',
+	'auth.apiKeyRequiredDetail': 'Please run DeepSeek: Set API Key to configure.',
+	'auth.prompt': 'Enter your DeepSeek API key',
+	'auth.placeholder': 'sk-...',
+	'auth.emptyValidation': 'API key cannot be empty',
+	'auth.prefixValidation': 'API key should start with "sk-"',
+	'auth.saved': 'DeepSeek API key saved securely.',
+	'auth.removed': 'DeepSeek API key removed.',
+	'auth.notConfigured': 'DeepSeek API key not configured. Run "DeepSeek: Set API Key" from the Command Palette.',
+
+	// Thinking Effort
+	'thinking.none': 'None',
+	'thinking.none.desc': 'Disable thinking for faster responses',
+	'thinking.high': 'High',
+	'thinking.high.desc': 'Recommended for most tasks',
+	'thinking.max': 'Max',
+	'thinking.max.desc': 'Maximum reasoning depth for complex agent tasks',
+
+	// Vision
+	'vision.noModel': 'No language models available in your VS Code environment.',
+	'vision.pickPlaceholder': 'Pick a model to describe image attachments (default: {0})',
+	'vision.current': 'current',
+	'vision.proxyUsing': 'Using vision proxy model: {0}',
+	'vision.notFound': 'Vision model "{0}" not found.',
+	'vision.unavailable': 'No vision model available; images will be dropped.',
+	'vision.proxyError': 'Vision proxy error:',
+	'vision.unableToDescribe': '[Image: unable to describe]',
+
+	// Extension
+	'extension.activateFailed': 'DeepSeek failed to activate. Run "DeepSeek: Show Logs" for details.',
+	'extension.deactivateFailed': 'Failed to prepare DeepSeek provider for deactivate',
+	'extension.welcomeFailed': 'Failed to show DeepSeek welcome prompt',
+
+	// Status bar / context display
+	'status.model': 'Model',
+	'status.thinking': 'Thinking',
+	'status.promptTokens': 'Prompt Tokens',
+	'status.completionTokens': 'Completion Tokens',
+	'status.totalTokens': 'Total Tokens',
+	'status.cacheHit': 'Cache Hit',
+	'status.cacheMiss': 'Cache Miss',
+	'status.cacheRate': 'Cache Hit Rate',
+	'status.charsPerToken': 'Chars/Token',
+	'status.noData': 'Waiting for first API call...',
+	'status.clickForDetail': 'Click for details',
+
+	// Log output
+	'log.tokens': 'tokens: prompt={0} completion={1}',
+	'log.cache': 'cache: hit={0} miss={1} rate={2}%',
+	'log.charsPerToken': 'chars/tok={0}',
+};
+
+/**
+ * 获取翻译文本。支持 {0}, {1}, ... 占位符替换。
+ */
+export function t(key: string, ...args: (string | number)[]): string {
+	const dict = isZh() ? zh : en;
+	let text = dict[key] ?? en[key] ?? key;
+
+	for (let i = 0; i < args.length; i++) {
+		text = text.replace(`{${i}}`, String(args[i]));
+	}
+
+	return text;
+}
+
+/**
+ * 检查当前是否为中文环境。
+ */
+export function isZhLocale(): boolean {
+	return isZh();
+}

--- a/src/provider/index.ts
+++ b/src/provider/index.ts
@@ -1,21 +1,21 @@
 import * as vscode from 'vscode';
 import { AuthManager } from '../auth';
 import { DeepSeekClient } from '../client';
+import { type UsageSnapshot } from '../context-display';
+import { t } from '../i18n';
 import { logger } from '../logger';
 import type {
-	DeepSeekToolCall,
-	ModelDefinition
+    DeepSeekToolCall,
+    ModelDefinition
 } from '../types';
 import { MODELS } from '../types';
 import { type ReasoningEntry, pruneReasoningCache } from './cache';
 import { convertMessages, convertTools, countMessageChars } from './convert';
 import {
-	createVisionModelGetter,
-	resolveImageMessages,
-	setVisionProxyModel,
+    createVisionModelGetter,
+    resolveImageMessages,
+    setVisionProxyModel,
 } from './vision';
-
-const API_KEY_REQUIRED_DETAIL = 'Please run DeepSeek: Set API Key to configure.';
 
 /**
  * NOTE: Non-public API surface.
@@ -30,23 +30,30 @@ const API_KEY_REQUIRED_DETAIL = 'Please run DeepSeek: Set API Key to configure.'
  * If/when VS Code stabilizes these as proposed API, switch to the official
  * types and drop the casts below.
  */
-const THINKING_EFFORT_CONFIGURATION_SCHEMA = {
-	properties: {
-		reasoningEffort: {
-			type: 'string',
-			title: 'Thinking Effort',
-			enum: ['none', 'high', 'max'],
-			enumItemLabels: ['None', 'High', 'Max'],
-			enumDescriptions: [
-				'Disable thinking for faster responses',
-				'Recommended for most tasks',
-				'Maximum reasoning depth for complex agent tasks',
-			],
-			default: 'high',
-			group: 'navigation',
+/**
+ * Build thinking effort configuration schema dynamically.
+ * Called at runtime so t() picks up the current locale (respects
+ * deepseek-copilot.language config changes).
+ */
+function buildThinkingEffortSchema() {
+	return {
+		properties: {
+			reasoningEffort: {
+				type: 'string',
+				title: t('status.thinking'),
+				enum: ['none', 'high', 'max'],
+				enumItemLabels: [t('thinking.none'), t('thinking.high'), t('thinking.max')],
+				enumDescriptions: [
+					t('thinking.none.desc'),
+					t('thinking.high.desc'),
+					t('thinking.max.desc'),
+				],
+				default: 'high',
+				group: 'navigation',
+			},
 		},
-	},
-} as const;
+	} as const;
+}
 
 type ThinkingEffort = 'none' | 'high' | 'max';
 
@@ -69,7 +76,7 @@ type ModelConfigurationOptions = vscode.ProvideLanguageModelChatResponseOptions 
 type ModelPickerChatInformation = vscode.LanguageModelChatInformation & {
 	readonly isUserSelectable: boolean;
 	readonly statusIcon?: vscode.ThemeIcon;
-	readonly configurationSchema?: typeof THINKING_EFFORT_CONFIGURATION_SCHEMA;
+	readonly configurationSchema?: ReturnType<typeof buildThinkingEffortSchema>;
 };
 
 /**
@@ -94,6 +101,16 @@ export class DeepSeekChatProvider implements vscode.LanguageModelChatProvider {
 	 * Updated via exponential moving average each time the API reports real token counts.
 	 */
 	private charsPerToken = 4.0;
+
+	/** 上下文显示器用量回调 */
+	private usageCallbacks: Array<(modelId: string, thinkingEffort: string, usage: UsageSnapshot) => void> = [];
+
+	/**
+	 * 注册用量更新回调，供 ContextDisplay 使用。
+	 */
+	onUsageUpdate(cb: (modelId: string, thinkingEffort: string, usage: UsageSnapshot) => void): void {
+		this.usageCallbacks.push(cb);
+	}
 
 	constructor(context: vscode.ExtensionContext) {
 		this.authManager = new AuthManager(context);
@@ -136,7 +153,7 @@ export class DeepSeekChatProvider implements vscode.LanguageModelChatProvider {
 	async clearApiKey(): Promise<void> {
 		await this.authManager.deleteApiKey();
 		this.onDidChangeLanguageModelChatInformationEmitter.fire();
-		vscode.window.showInformationMessage('DeepSeek API key removed.');
+		vscode.window.showInformationMessage(t('auth.removed'));
 	}
 
 	async hasApiKey(): Promise<boolean> {
@@ -189,9 +206,7 @@ export class DeepSeekChatProvider implements vscode.LanguageModelChatProvider {
 	): Promise<void> {
 		const apiKey = await this.authManager.getApiKey();
 		if (!apiKey) {
-			throw new Error(
-				'DeepSeek API key not configured. Run "DeepSeek: Set API Key" from the Command Palette.',
-			);
+			throw new Error(t('auth.notConfigured'));
 		}
 
 		const baseUrl = this.authManager.getBaseUrl();
@@ -328,15 +343,32 @@ export class DeepSeekChatProvider implements vscode.LanguageModelChatProvider {
 								this.charsPerToken * 0.7 + observedRatio * 0.3;
 						}
 
-						// Log KV cache hit stats for observability.
+						// Notify context display
 						const cacheHit = usage.prompt_cache_hit_tokens ?? 0;
 						const cacheMiss = usage.prompt_cache_miss_tokens ?? 0;
+						const snapshot: UsageSnapshot = {
+							promptTokens: usage.prompt_tokens,
+							completionTokens: usage.completion_tokens,
+							totalTokens: usage.total_tokens,
+							cacheHitTokens: cacheHit,
+							cacheMissTokens: cacheMiss,
+							charsPerToken: this.charsPerToken,
+						};
+						for (const cb of this.usageCallbacks) {
+							try {
+								cb(modelInfo.id, thinkingEffort, snapshot);
+							} catch (error) {
+								logger.debug('Context display callback error', error);
+							}
+						}
+
+						// Log KV cache hit stats for observability.
 						const cacheTotal = cacheHit + cacheMiss;
 						const hitRate = cacheTotal > 0 ? ((cacheHit / cacheTotal) * 100).toFixed(0) : 'n/a';
 						logger.info(
-							`tokens: prompt=${usage.prompt_tokens} completion=${usage.completion_tokens}` +
-							` | cache: hit=${cacheHit} miss=${cacheMiss} rate=${hitRate}%` +
-							` | chars/tok=${this.charsPerToken.toFixed(2)}`,
+							t('log.tokens', usage.prompt_tokens, usage.completion_tokens) +
+							' | ' + t('log.cache', cacheHit, cacheMiss, hitRate) +
+							' | ' + t('log.charsPerToken', Number(this.charsPerToken.toFixed(2))),
 						);
 					},
 				},
@@ -378,13 +410,14 @@ function toChatInfo(
 	m: ModelDefinition,
 	hasApiKey: boolean,
 ): ModelPickerChatInformation {
+	const noKeyDetail = t('auth.apiKeyRequiredDetail');
 	return {
 		id: m.id,
 		name: m.name,
 		family: m.family,
 		version: m.version,
-		detail: hasApiKey ? m.detail : API_KEY_REQUIRED_DETAIL,
-		tooltip: hasApiKey ? undefined : API_KEY_REQUIRED_DETAIL,
+		detail: hasApiKey ? t(m.detail) : noKeyDetail,
+		tooltip: hasApiKey ? undefined : noKeyDetail,
 		statusIcon: hasApiKey ? undefined : new vscode.ThemeIcon('warning'),
 		maxInputTokens: m.maxInputTokens,
 		maxOutputTokens: m.maxOutputTokens,
@@ -394,7 +427,7 @@ function toChatInfo(
 			imageInput: m.capabilities.imageInput,
 		},
 		...(m.capabilities.thinking
-			? { configurationSchema: THINKING_EFFORT_CONFIGURATION_SCHEMA }
+			? { configurationSchema: buildThinkingEffortSchema() }
 			: {}),
 	};
 }

--- a/src/provider/vision.ts
+++ b/src/provider/vision.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { t } from '../i18n';
 import { logger } from '../logger';
 
 const DEFAULT_VISION_MODEL_ID = 'oswe-vscode-prime';
@@ -25,7 +26,7 @@ export async function resolveImageMessages(
 
 	const visionModel = await getModel();
 	if (!visionModel) {
-		logger.warn('No vision model available; images will be dropped.');
+		logger.warn(t('vision.unavailable'));
 		return messages.map((m) => {
 			const filtered = (m.content as readonly vscode.LanguageModelInputPart[]).filter(
 				(p) => !isImageDataPart(p),
@@ -73,8 +74,8 @@ export async function resolveImageMessages(
 				new vscode.LanguageModelTextPart(`[Image Description: ${description.trim()}]`),
 			);
 		} catch (err) {
-			logger.error('Vision proxy error:', err);
-			otherParts.push(new vscode.LanguageModelTextPart('[Image: unable to describe]'));
+			logger.error(t('vision.proxyError'), err);
+			otherParts.push(new vscode.LanguageModelTextPart(t('vision.unableToDescribe')));
 		}
 
 		result.push({
@@ -110,11 +111,11 @@ export function createVisionModelGetter(): {
 				const id = getConfiguredVisionModelId() ?? DEFAULT_VISION_MODEL_ID;
 				const models = await vscode.lm.selectChatModels({ id });
 				if (models.length > 0) {
-					logger.info(`Using vision proxy model: ${models[0].id}`);
+					logger.info(t('vision.proxyUsing', models[0].id));
 					visionModel = models[0];
 					return models[0];
 				}
-				logger.warn(`Vision model "${id}" not found.`);
+				logger.warn(t('vision.notFound', id));
 				return undefined;
 			})();
 
@@ -136,7 +137,7 @@ export async function setVisionProxyModel(): Promise<void> {
 	const candidates = allModels.filter((m) => m.vendor !== 'deepseek');
 
 	if (candidates.length === 0) {
-		vscode.window.showInformationMessage('No language models available in your VS Code environment.');
+		vscode.window.showInformationMessage(t('vision.noModel'));
 		return;
 	}
 
@@ -145,11 +146,11 @@ export async function setVisionProxyModel(): Promise<void> {
 	const items = candidates.map((m) => ({
 		label: m.id,
 		description: `vendor: ${m.vendor}`,
-		detail: m.id === currentId ? '✓ current' : undefined,
+		detail: m.id === currentId ? `✓ ${t('vision.current')}` : undefined,
 	}));
 
 	const picked = await vscode.window.showQuickPick(items, {
-		placeHolder: `Pick a model to describe image attachments (default: ${DEFAULT_VISION_MODEL_ID})`,
+		placeHolder: t('vision.pickPlaceholder', DEFAULT_VISION_MODEL_ID),
 		matchOnDescription: true,
 	});
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,7 @@
  * Shared types for the DeepSeek Copilot extension.
  */
 
+
 // ---- API request/response types ----
 
 export interface DeepSeekMessage {
@@ -113,7 +114,8 @@ export const MODELS: ModelDefinition[] = [
 		name: 'DeepSeek V4 Flash',
 		family: 'deepseek',
 		version: 'v4',
-		detail: 'Fast, general-purpose model',
+		/** i18n key — translated in provider toChatInfo() */
+		detail: 'model.flash.detail',
 		maxInputTokens: 1048576,
 		maxOutputTokens: 393216,
 		capabilities: {
@@ -128,7 +130,8 @@ export const MODELS: ModelDefinition[] = [
 		name: 'DeepSeek V4 Pro',
 		family: 'deepseek',
 		version: 'v4',
-		detail: 'Most capable reasoning model',
+		/** i18n key — translated in provider toChatInfo() */
+		detail: 'model.pro.detail',
 		maxInputTokens: 1048576,
 		maxOutputTokens: 393216,
 		capabilities: {


### PR DESCRIPTION
## 变更摘要

### 国际化中文适配
- 扩展界面随 VS Code 显示语言自动切换中/英文
- 覆盖范围：命令面板、模型选择器、Thinking Effort 标签、设置页描述、API Key 配置提示、视觉代理选择器、状态栏等全部用户可见文本
- 实现方式：package.nls.json / package.nls.zh-cn.json + 运行时 i18n 模块

### 上下文用量状态栏
- 右下角新增状态栏项，实时展示当前模型 + 1M 上下文窗口占比进度条
- 悬停显示 Markdown 用量面板（输入/输出/缓存命中率等）
- 关闭 VS Code 重启后自动恢复上次会话用量
- 点击状态栏直接打开日志输出
<img width="146" height="233" alt="image" src="https://github.com/user-attachments/assets/af1ae874-4ae4-449f-8ed7-3f85284b1928" />

### 涉及文件
| 类型 | 文件 |
|------|------|
| 新增 | src/i18n.ts, src/context-display.ts |
| 新增 | package.nls.json, package.nls.zh-cn.json |
| 修改 | package.json, src/extension.ts, src/auth.ts, src/types.ts, src/provider/index.ts, src/provider/vision.ts |