### PR TITLE
refactor: reorganize project structure

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,6 +1,5 @@
-import * as vscode from 'vscode';
-
-const API_KEY_SECRET = 'deepseek-copilot.apiKey';
+import vscode from 'vscode';
+import { API_KEY_SECRET } from './consts';
 
 /**
  * Manages DeepSeek API key via VS Code SecretStorage (secure) with
@@ -80,33 +79,5 @@ export class AuthManager {
 		}
 
 		return false;
-	}
-
-	/**
-	 * Get base URL from settings.
-	 */
-	getBaseUrl(): string {
-		const config = vscode.workspace.getConfiguration('deepseek-copilot');
-		return config.get<string>('baseUrl') || 'https://api.deepseek.com';
-	}
-
-	/**
-	 * Resolve the API model ID to send to the DeepSeek endpoint.
-	 * Users can override the default IDs via settings to support compatible APIs.
-	 */
-	getApiModelId(vscodeModelId: string): string {
-		const config = vscode.workspace.getConfiguration('deepseek-copilot');
-		const overrides = config.get<Record<string, string>>('modelIdOverrides');
-		const override = overrides?.[vscodeModelId]?.trim();
-		return override || vscodeModelId;
-	}
-
-	/**
-	 * Get max tokens limit (0 = no limit).
-	 */
-	getMaxTokens(): number | undefined {
-		const config = vscode.workspace.getConfiguration('deepseek-copilot');
-		const value = config.get<number>('maxTokens', 0);
-		return value > 0 ? value : undefined;
 	}
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,35 @@
+import vscode from 'vscode';
+import { CONFIG_SECTION } from './consts';
+
+/**
+ * Get DeepSeek API base URL from settings.
+ * Falls back to the official endpoint when not configured.
+ */
+export function getBaseUrl(): string {
+	const config = vscode.workspace.getConfiguration(CONFIG_SECTION);
+	return config.get<string>('baseUrl') || 'https://api.deepseek.com';
+}
+
+/**
+ * Resolve the API model ID to send to the endpoint.
+ *
+ * Users can override model IDs via the `modelIdOverrides` setting object
+ * (e.g. for third-party API proxies). Falls back to the VS Code model ID
+ * when no override is configured.
+ */
+export function getApiModelId(vscodeModelId: string): string {
+	const config = vscode.workspace.getConfiguration(CONFIG_SECTION);
+	const overrides = config.get<Record<string, string>>('modelIdOverrides');
+	const override = overrides?.[vscodeModelId]?.trim();
+	return override || vscodeModelId;
+}
+
+/**
+ * Get the configured max output tokens limit.
+ * Returns `undefined` when set to 0 (API default — no limit).
+ */
+export function getMaxTokens(): number | undefined {
+	const config = vscode.workspace.getConfiguration(CONFIG_SECTION);
+	const value = config.get<number>('maxTokens', 0);
+	return value > 0 ? value : undefined;
+}

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,0 +1,101 @@
+import type { ModelDefinition } from './types';
+
+/**
+ * Compile-time constants shared across the extension.
+ *
+ * These do NOT depend on the VS Code runtime (no workspace configuration,
+ * no secrets API). For run-time settings reads see `config.ts`.
+ */
+
+/** VS Code configuration section prefix for all extension settings. */
+export const CONFIG_SECTION = 'deepseek-copilot';
+
+// ---- Secret keys ----
+
+/** SecretStorage key for the DeepSeek API key. */
+export const API_KEY_SECRET = 'deepseek-copilot.apiKey';
+
+/** memento key tracking whether the welcome walkthrough has been shown. */
+export const WELCOME_SHOWN_KEY = 'deepseek-copilot.welcomeShown';
+
+// ---- Walkthrough ----
+
+/** Walkthrough contribution ID. */
+export const WALKTHROUGH_ID = 'Vizards.deepseek-v4-for-copilot#deepseekGettingStarted';
+
+// ---- Model picker ----
+
+/** Detail text shown in the model picker when no API key is configured. */
+export const API_KEY_REQUIRED_DETAIL = 'Please run DeepSeek: Set API Key to configure.';
+
+/** Per-model configuration schema consumed by Copilot Chat's model picker. */
+export const THINKING_EFFORT_CONFIGURATION_SCHEMA = {
+	properties: {
+		reasoningEffort: {
+			type: 'string',
+			title: 'Thinking Effort',
+			enum: ['none', 'high', 'max'],
+			enumItemLabels: ['None', 'High', 'Max'],
+			enumDescriptions: [
+				'Disable thinking for faster responses',
+				'Recommended for most tasks',
+				'Maximum reasoning depth for complex agent tasks',
+			],
+			default: 'high',
+			group: 'navigation',
+		},
+	},
+} as const;
+
+// ---- Vision proxy ----
+
+/** Default model ID used for the vision proxy when auto-detection is enabled. */
+export const DEFAULT_VISION_MODEL_ID = 'oswe-vscode-prime';
+
+/**
+ * Prompt sent to the vision proxy model when describing image attachments
+ * before forwarding them to text-only DeepSeek models.
+ */
+export const IMAGE_DESCRIPTION_PROMPT =
+	'Describe the visual contents of this image in detail, including any text, objects, people, or context that would be relevant for understanding it. Focus on factual visual elements.';
+
+// ---- Cache ----
+
+/** Max entries in the reasoning-content cache before eviction kicks in. */
+export const MAX_CACHE_SIZE = 200;
+
+// ---- Model registry ----
+
+/** Available DeepSeek models exposed through the language model provider. */
+export const MODELS: ModelDefinition[] = [
+	{
+		id: 'deepseek-v4-flash',
+		name: 'DeepSeek V4 Flash',
+		family: 'deepseek',
+		version: 'v4',
+		detail: 'Fast, general-purpose model',
+		maxInputTokens: 1048576,
+		maxOutputTokens: 393216,
+		capabilities: {
+			toolCalling: true,
+			imageInput: true,
+			thinking: true,
+		},
+		requiresThinkingParam: true,
+	},
+	{
+		id: 'deepseek-v4-pro',
+		name: 'DeepSeek V4 Pro',
+		family: 'deepseek',
+		version: 'v4',
+		detail: 'Most capable reasoning model',
+		maxInputTokens: 1048576,
+		maxOutputTokens: 393216,
+		capabilities: {
+			toolCalling: true,
+			imageInput: true,
+			thinking: true,
+		},
+		requiresThinkingParam: true,
+	},
+];

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,9 +1,7 @@
-import * as vscode from 'vscode';
+import vscode from 'vscode';
+import { WALKTHROUGH_ID, WELCOME_SHOWN_KEY } from './consts';
 import { logger } from './logger';
 import { DeepSeekChatProvider } from './provider';
-
-const WELCOME_SHOWN_KEY = 'deepseek-copilot.welcomeShown';
-const WALKTHROUGH_ID = 'Vizards.deepseek-v4-for-copilot#deepseekGettingStarted';
 
 let activeProvider: DeepSeekChatProvider | undefined;
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,4 +1,4 @@
-import * as vscode from 'vscode';
+import vscode from 'vscode';
 
 let channel: vscode.OutputChannel | undefined;
 

--- a/src/provider/cache.ts
+++ b/src/provider/cache.ts
@@ -1,3 +1,5 @@
+import { MAX_CACHE_SIZE } from '../consts';
+
 /**
  * Reasoning cache: persists across turns so multi-turn tool-call conversations
  * can inject reasoning_content back into prior assistant messages.
@@ -13,8 +15,6 @@ export interface ReasoningEntry {
 	text: string;
 	timestamp: number;
 }
-
-export const MAX_CACHE_SIZE = 200;
 
 export function pruneReasoningCache(
 	cache: Map<string, ReasoningEntry>,

--- a/src/provider/convert.ts
+++ b/src/provider/convert.ts
@@ -1,4 +1,4 @@
-import * as vscode from 'vscode';
+import vscode from 'vscode';
 import type { DeepSeekMessage, DeepSeekTool, DeepSeekToolCall } from '../types';
 import type { ReasoningEntry } from './cache';
 

--- a/src/provider/index.ts
+++ b/src/provider/index.ts
@@ -1,12 +1,13 @@
-import * as vscode from 'vscode';
+import vscode from 'vscode';
 import { AuthManager } from '../auth';
 import { DeepSeekClient } from '../client';
+import { getApiModelId, getBaseUrl, getMaxTokens } from '../config';
+import { API_KEY_REQUIRED_DETAIL, MODELS, THINKING_EFFORT_CONFIGURATION_SCHEMA } from '../consts';
 import { logger } from '../logger';
 import type {
 	DeepSeekToolCall,
 	ModelDefinition
 } from '../types';
-import { MODELS } from '../types';
 import { type ReasoningEntry, pruneReasoningCache } from './cache';
 import { convertMessages, convertTools, countMessageChars } from './convert';
 import {
@@ -14,8 +15,6 @@ import {
 	resolveImageMessages,
 	setVisionProxyModel,
 } from './vision';
-
-const API_KEY_REQUIRED_DETAIL = 'Please run DeepSeek: Set API Key to configure.';
 
 /**
  * NOTE: Non-public API surface.
@@ -30,23 +29,6 @@ const API_KEY_REQUIRED_DETAIL = 'Please run DeepSeek: Set API Key to configure.'
  * If/when VS Code stabilizes these as proposed API, switch to the official
  * types and drop the casts below.
  */
-const THINKING_EFFORT_CONFIGURATION_SCHEMA = {
-	properties: {
-		reasoningEffort: {
-			type: 'string',
-			title: 'Thinking Effort',
-			enum: ['none', 'high', 'max'],
-			enumItemLabels: ['None', 'High', 'Max'],
-			enumDescriptions: [
-				'Disable thinking for faster responses',
-				'Recommended for most tasks',
-				'Maximum reasoning depth for complex agent tasks',
-			],
-			default: 'high',
-			group: 'navigation',
-		},
-	},
-} as const;
 
 type ThinkingEffort = 'none' | 'high' | 'max';
 
@@ -194,13 +176,13 @@ export class DeepSeekChatProvider implements vscode.LanguageModelChatProvider {
 			);
 		}
 
-		const baseUrl = this.authManager.getBaseUrl();
+		const baseUrl = getBaseUrl();
 		const client = new DeepSeekClient(baseUrl, apiKey);
 
-		const modelDef = findModel(modelInfo.id);
+		const modelDef = MODELS.find(m => m.id === modelInfo.id);
 		const isThinkingModel = modelDef?.capabilities.thinking ?? false;
 		const thinkingEffort = getConfiguredThinkingEffort(options as ModelConfigurationOptions);
-		const maxTokens = this.authManager.getMaxTokens();
+		const maxTokens = getMaxTokens();
 
 		// Heuristic: detect conversation start to clear stale cache.
 		if (messages.length <= 2) {
@@ -231,7 +213,7 @@ export class DeepSeekChatProvider implements vscode.LanguageModelChatProvider {
 		return new Promise<void>((resolve, reject) => {
 			client.streamChatCompletion(
 				{
-					model: this.authManager.getApiModelId(modelInfo.id),
+					model: getApiModelId(modelInfo.id),
 					messages: deepseekMessages,
 					stream: true,
 					tools,
@@ -369,10 +351,6 @@ export class DeepSeekChatProvider implements vscode.LanguageModelChatProvider {
 }
 
 // ---- Helpers ----
-
-function findModel(id: string): ModelDefinition | undefined {
-	return MODELS.find((m) => m.id === id);
-}
 
 function toChatInfo(
 	m: ModelDefinition,

--- a/src/provider/vision.ts
+++ b/src/provider/vision.ts
@@ -1,10 +1,6 @@
-import * as vscode from 'vscode';
+import vscode from 'vscode';
+import { DEFAULT_VISION_MODEL_ID, IMAGE_DESCRIPTION_PROMPT } from '../consts';
 import { logger } from '../logger';
-
-const DEFAULT_VISION_MODEL_ID = 'oswe-vscode-prime';
-
-export const IMAGE_DESCRIPTION_PROMPT =
-	'Describe the visual contents of this image in detail, including any text, objects, people, or context that would be relevant for understanding it. Focus on factual visual elements.';
 
 /**
  * Resolve any image parts in user messages by forwarding them to a vision

--- a/src/types.ts
+++ b/src/types.ts
@@ -106,36 +106,3 @@ export interface ModelDefinition {
 	};
 	requiresThinkingParam: boolean;
 }
-
-export const MODELS: ModelDefinition[] = [
-	{
-		id: 'deepseek-v4-flash',
-		name: 'DeepSeek V4 Flash',
-		family: 'deepseek',
-		version: 'v4',
-		detail: 'Fast, general-purpose model',
-		maxInputTokens: 1048576,
-		maxOutputTokens: 393216,
-		capabilities: {
-			toolCalling: true,
-			imageInput: true,
-			thinking: true,
-		},
-		requiresThinkingParam: true,
-	},
-	{
-		id: 'deepseek-v4-pro',
-		name: 'DeepSeek V4 Pro',
-		family: 'deepseek',
-		version: 'v4',
-		detail: 'Most capable reasoning model',
-		maxInputTokens: 1048576,
-		maxOutputTokens: 393216,
-		capabilities: {
-			toolCalling: true,
-			imageInput: true,
-			thinking: true,
-		},
-		requiresThinkingParam: true,
-	},
-];


### PR DESCRIPTION
### Summary

A round of structural cleanup to improve maintainability and set up for future contributions.

### Changes

- **`src/config.ts`** (new) — extract pure settings reads (`getBaseUrl`, `getApiModelId`, `getMaxTokens`) from `AuthManager`. `AuthManager` is now strictly about API key lifecycle.

- **`src/consts.ts`** (new) — centralize all compile-time constants from 5 source files into one module, grouped by chapter with JSDoc. Includes: config keys, secret keys, walkthrough IDs, model picker UI, vision proxy defaults, cache limits, and the model registry (`MODELS`).

- **`src/types.ts`** — remove `MODELS` constant, leaving only pure type definitions.

- **Inline `findModel`** — one-line helper replaced with `MODELS.find()` at the single call site.

- **`import * as vscode` → `import vscode`** — unified across all source files (already has `esModuleInterop: true` in tsconfig).

### Why

- New contributors can see all constants in one place instead of hunting across files
- Adding a future model requires only one entry in `consts.ts` and `package.json`
- `AuthManager` is now single-responsibility
- Default vscode imports are shorter and idiomatic under `esModuleInterop`