### PR TITLE
fix: thinking effort dropdown missing on first launch

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
     "vscode": "^1.116.0",
     "node": ">=24"
   },
+  "extensionDependencies": [
+    "github.copilot-chat"
+  ],
   "extensionKind": [
     "workspace"
   ],

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -43,13 +43,13 @@ export function activate(context: vscode.ExtensionContext) {
 		// Chat to re-query our provider through the full (non-cached) path, which
 		// correctly picks up configurationSchema.
 		//
-		// This works because registerLanguageModelChatProvider() is synchronous —
-		// the provider is fully registered before the async event is dispatched,
-		// so Copilot Chat always receives complete model information when it
-		// processes the event. The extensionDependencies on github.copilot-chat
-		// in package.json additionally guarantees Copilot Chat is fully activated
-		// before this extension's activate() runs, eliminating any activation
-		// ordering race.
+		// This works because registerLanguageModelChatProvider() is synchronous,
+		// so the provider is fully registered before we fire the refresh and the
+		// host has already subscribed to receive the change. Copilot Chat can then
+		// re-query complete model information through the non-cached path. The
+		// extensionDependencies on github.copilot-chat in package.json
+		// additionally guarantees Copilot Chat is fully activated before this
+		// extension's activate() runs, eliminating any activation ordering race.
 		provider.refreshModelPicker();
 
 		void showWelcomeIfNeeded(context, provider).catch((error) => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -33,6 +33,25 @@ export function activate(context: vscode.ExtensionContext) {
 			vscode.lm.registerLanguageModelChatProvider('deepseek', provider),
 		);
 
+		// Fix(#12): configurationSchema (Thinking Effort dropdown) is a non-public
+		// field that Copilot Chat does not persist in its chatLanguageModels.json
+		// cache. On startup, Copilot Chat initialises the model picker from cache
+		// and silently drops configurationSchema, so the per-model config menu
+		// never appears on first launch.
+		//
+		// Re-firing onDidChangeLanguageModelChatInformation here forces Copilot
+		// Chat to re-query our provider through the full (non-cached) path, which
+		// correctly picks up configurationSchema.
+		//
+		// This works because registerLanguageModelChatProvider() is synchronous —
+		// the provider is fully registered before the async event is dispatched,
+		// so Copilot Chat always receives complete model information when it
+		// processes the event. The extensionDependencies on github.copilot-chat
+		// in package.json additionally guarantees Copilot Chat is fully activated
+		// before this extension's activate() runs, eliminating any activation
+		// ordering race.
+		provider.refreshModelPicker();
+
 		void showWelcomeIfNeeded(context, provider).catch((error) => {
 			logger.warn('Failed to show DeepSeek welcome prompt', error);
 		});

--- a/src/provider/index.ts
+++ b/src/provider/index.ts
@@ -119,6 +119,11 @@ export class DeepSeekChatProvider implements vscode.LanguageModelChatProvider {
 		return this.authManager.hasApiKey();
 	}
 
+	/** Force Copilot Chat to re-query model information (including configurationSchema). */
+	refreshModelPicker(): void {
+		this.onDidChangeLanguageModelChatInformationEmitter.fire();
+	}
+
 	async prepareForDeactivate(): Promise<void> {
 		this.isActive = false;
 		this.onDidChangeLanguageModelChatInformationEmitter.fire();


### PR DESCRIPTION
## Summary

Fix #12 — the Thinking Effort dropdown (per-model configuration menu) not appearing on first VS Code launch.

## Root Cause

Copilot Chat persists model metadata in `chatLanguageModels.json` on shutdown and restores it on startup. The `configurationSchema` field — which declares the Thinking Effort dropdown — is a non-public extension on `LanguageModelChatInformation` that Copilot Chat does not write to cache. On startup, Copilot Chat initialises the model picker from cache and silently omits `configurationSchema`, so the per-model config menu never appears. Clicking `Manage Language Models` forces a full (non-cached) re-query and works around the issue.

## Fix

Two changes:

- **Re-fire `onDidChangeLanguageModelChatInformation` immediately after `registerLanguageModelChatProvider()`** — because the registration call is synchronous, our provider is fully registered by the time Copilot Chat processes the async event, so it walks the complete query path and correctly picks up `configurationSchema`.

- **Add `extensionDependencies: ["github.copilot-chat"]` to `package.json`** — guarantees Copilot Chat is fully activated before this extension's `activate()` runs, eliminating any activation-ordering race at the platform level.

## Changes

- `src/extension.ts` — call `provider.refreshModelPicker()` once after provider registration; update comment to explain the mechanism.
- `src/provider/index.ts` — expose `refreshModelPicker()` as a public method.
- `package.json` — add `extensionDependencies` on `github.copilot-chat`.
