### PR TITLE
feat: Chinese (zh-cn) i18n support

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,39 +55,39 @@
     "commands": [
       {
         "command": "deepseek-copilot.setApiKey",
-        "title": "DeepSeek: Set API Key"
+        "title": "%deepseek-copilot.command.setApiKey%"
       },
       {
         "command": "deepseek-copilot.getApiKey",
-        "title": "DeepSeek: Get API Key"
+        "title": "%deepseek-copilot.command.getApiKey%"
       },
       {
         "command": "deepseek-copilot.clearApiKey",
-        "title": "DeepSeek: Clear API Key"
+        "title": "%deepseek-copilot.command.clearApiKey%"
       },
       {
         "command": "deepseek-copilot.setVisionModel",
-        "title": "DeepSeek: Set Vision Proxy Model"
+        "title": "%deepseek-copilot.command.setVisionModel%"
       },
       {
         "command": "deepseek-copilot.openSettings",
-        "title": "DeepSeek: Open Settings"
+        "title": "%deepseek-copilot.command.openSettings%"
       },
       {
         "command": "deepseek-copilot.showLogs",
-        "title": "DeepSeek: Show Logs"
+        "title": "%deepseek-copilot.command.showLogs%"
       }
     ],
     "walkthroughs": [
       {
         "id": "deepseekGettingStarted",
-        "title": "DeepSeek V4 for Copilot Chat",
-        "description": "Set up DeepSeek V4 models in Copilot Chat.",
+        "title": "%deepseek-copilot.walkthrough.title%",
+        "description": "%deepseek-copilot.walkthrough.description%",
         "steps": [
           {
             "id": "setApiKey",
-            "title": "Set your DeepSeek API key",
-            "description": "[Get an API key](command:deepseek-copilot.getApiKey) from deepseek.com.\n[Set API Key](command:deepseek-copilot.setApiKey)",
+            "title": "%deepseek-copilot.walkthrough.setApiKey.title%",
+            "description": "%deepseek-copilot.walkthrough.setApiKey.description%",
             "media": {
               "markdown": "resources/walkthrough/set-api-key.md"
             },
@@ -97,8 +97,8 @@
           },
           {
             "id": "showModels",
-            "title": "Show DeepSeek models",
-            "description": "If the models are hidden, open VS Code's Language Models manager and show the DeepSeek models.\n[Open Language Models](command:workbench.action.chat.manage)",
+            "title": "%deepseek-copilot.walkthrough.showModels.title%",
+            "description": "%deepseek-copilot.walkthrough.showModels.description%",
             "media": {
               "markdown": "resources/walkthrough/show-models.md"
             }
@@ -107,18 +107,18 @@
       }
     ],
     "configuration": {
-      "title": "DeepSeek Copilot",
+      "title": "%deepseek-copilot.config.title%",
       "properties": {
         "deepseek-copilot.baseUrl": {
           "type": "string",
           "default": "https://api.deepseek.com",
-          "description": "DeepSeek API base URL. Defaults to official DeepSeek API endpoint."
+          "description": "%deepseek-copilot.config.baseUrl.description%"
         },
         "deepseek-copilot.maxTokens": {
           "type": "number",
           "default": 0,
           "minimum": 0,
-          "description": "Maximum number of output tokens per request. Set to 0 to use the API default (no limit). Useful for controlling costs."
+          "description": "%deepseek-copilot.config.maxTokens.description%"
         },
         "deepseek-copilot.modelIdOverrides": {
           "type": "object",
@@ -126,29 +126,29 @@
             "deepseek-v4-flash": "deepseek-v4-flash",
             "deepseek-v4-pro": "deepseek-v4-pro"
           },
-          "description": "Override the API model ID sent for each DeepSeek model. Defaults are prefilled with official DeepSeek IDs; change them only when using a compatible third-party API that uses different model names.",
+          "description": "%deepseek-copilot.config.modelIdOverrides.description%",
           "additionalProperties": false,
           "properties": {
             "deepseek-v4-flash": {
               "type": "string",
-              "description": "API model ID for DeepSeek V4 Flash"
+              "description": "%deepseek-copilot.config.modelIdOverrides.deepseek-v4-flash.description%"
             },
             "deepseek-v4-pro": {
               "type": "string",
-              "description": "API model ID for DeepSeek V4 Pro"
+              "description": "%deepseek-copilot.config.modelIdOverrides.deepseek-v4-pro.description%"
             }
           }
         },
         "deepseek-copilot.visionModel": {
           "type": "string",
           "default": "",
-          "description": "Model ID for vision proxy (describes images for text-only DeepSeek models). Leave empty for auto-detection. Use 'DeepSeek: Set Vision Proxy Model' command to pick one from a list."
+          "description": "%deepseek-copilot.config.visionModel.description%"
         },
         "deepseek-copilot.visionPrompt": {
           "type": "string",
           "editPresentation": "multilineText",
           "default": "Describe the visual contents of this image in detail, including any text, objects, people, or context that would be relevant for understanding it. Focus on factual visual elements.",
-          "description": "Prompt sent to the vision proxy model when describing image attachments before forwarding them to DeepSeek."
+          "description": "%deepseek-copilot.config.visionPrompt.description%"
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
         "deepseek-copilot.visionPrompt": {
           "type": "string",
           "editPresentation": "multilineText",
-          "default": "Describe the visual contents of this image in detail, including any text, objects, people, or context that would be relevant for understanding it. Focus on factual visual elements.",
+          "default": "%deepseek-copilot.config.visionPrompt.default%",
           "description": "%deepseek-copilot.config.visionPrompt.description%"
         }
       }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deepseek-v4-for-copilot",
-  "displayName": "DeepSeek V4 for Copilot Chat",
-  "description": "Pick DeepSeek V4 Pro & Flash from the Copilot Chat model picker. Vision, thinking mode, agent tools — zero config, BYOK.",
+  "displayName": "%deepseek-copilot.displayName%",
+  "description": "%deepseek-copilot.description%",
   "icon": "resources/icon.png",
   "version": "0.3.0",
   "publisher": "Vizards",
@@ -49,7 +49,7 @@
     "languageModelChatProviders": [
       {
         "vendor": "deepseek",
-        "displayName": "DeepSeek"
+        "displayName": "%deepseek-copilot.providerDisplayName%"
       }
     ],
     "commands": [

--- a/package.nls.json
+++ b/package.nls.json
@@ -18,5 +18,6 @@
   "deepseek-copilot.config.modelIdOverrides.deepseek-v4-flash.description": "API model ID for DeepSeek V4 Flash",
   "deepseek-copilot.config.modelIdOverrides.deepseek-v4-pro.description": "API model ID for DeepSeek V4 Pro",
   "deepseek-copilot.config.visionModel.description": "Model ID for vision proxy (describes images for text-only DeepSeek models). Leave empty for auto-detection. Use 'DeepSeek: Set Vision Proxy Model' command to pick one from a list.",
-  "deepseek-copilot.config.visionPrompt.description": "Prompt sent to the vision proxy model when describing image attachments before forwarding them to DeepSeek."
+  "deepseek-copilot.config.visionPrompt.description": "Prompt sent to the vision proxy model when describing image attachments before forwarding them to DeepSeek.",
+  "deepseek-copilot.config.visionPrompt.default": "Describe the visual contents of this image in detail, including any text, objects, people, or context that would be relevant for understanding it. Focus on factual visual elements."
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -1,0 +1,22 @@
+{
+  "deepseek-copilot.command.setApiKey": "DeepSeek: Set API Key",
+  "deepseek-copilot.command.getApiKey": "DeepSeek: Get API Key",
+  "deepseek-copilot.command.clearApiKey": "DeepSeek: Clear API Key",
+  "deepseek-copilot.command.setVisionModel": "DeepSeek: Set Vision Proxy Model",
+  "deepseek-copilot.command.openSettings": "DeepSeek: Open Settings",
+  "deepseek-copilot.command.showLogs": "DeepSeek: Show Logs",
+  "deepseek-copilot.walkthrough.title": "DeepSeek V4 for Copilot Chat",
+  "deepseek-copilot.walkthrough.description": "Set up DeepSeek V4 models in Copilot Chat.",
+  "deepseek-copilot.walkthrough.setApiKey.title": "Set your DeepSeek API key",
+  "deepseek-copilot.walkthrough.setApiKey.description": "[Get an API key](command:deepseek-copilot.getApiKey) from deepseek.com.\n[Set API Key](command:deepseek-copilot.setApiKey)",
+  "deepseek-copilot.walkthrough.showModels.title": "Show DeepSeek models",
+  "deepseek-copilot.walkthrough.showModels.description": "If the models are hidden, open VS Code's Language Models manager and show the DeepSeek models.\n[Open Language Models](command:workbench.action.chat.manage)",
+  "deepseek-copilot.config.title": "DeepSeek Copilot",
+  "deepseek-copilot.config.baseUrl.description": "DeepSeek API base URL. Defaults to official DeepSeek API endpoint.",
+  "deepseek-copilot.config.maxTokens.description": "Maximum number of output tokens per request. Set to 0 to use the API default (no limit). Useful for controlling costs.",
+  "deepseek-copilot.config.modelIdOverrides.description": "Override the API model ID sent for each DeepSeek model. Defaults are prefilled with official DeepSeek IDs; change them only when using a compatible third-party API that uses different model names.",
+  "deepseek-copilot.config.modelIdOverrides.deepseek-v4-flash.description": "API model ID for DeepSeek V4 Flash",
+  "deepseek-copilot.config.modelIdOverrides.deepseek-v4-pro.description": "API model ID for DeepSeek V4 Pro",
+  "deepseek-copilot.config.visionModel.description": "Model ID for vision proxy (describes images for text-only DeepSeek models). Leave empty for auto-detection. Use 'DeepSeek: Set Vision Proxy Model' command to pick one from a list.",
+  "deepseek-copilot.config.visionPrompt.description": "Prompt sent to the vision proxy model when describing image attachments before forwarding them to DeepSeek."
+}

--- a/package.nls.json
+++ b/package.nls.json
@@ -1,4 +1,7 @@
 {
+  "deepseek-copilot.displayName": "DeepSeek V4 for Copilot Chat",
+  "deepseek-copilot.description": "Pick DeepSeek V4 Pro & Flash from the Copilot Chat model picker. Vision, thinking mode, agent tools — zero config, BYOK.",
+  "deepseek-copilot.providerDisplayName": "DeepSeek",
   "deepseek-copilot.command.setApiKey": "DeepSeek: Set API Key",
   "deepseek-copilot.command.getApiKey": "DeepSeek: Get API Key",
   "deepseek-copilot.command.clearApiKey": "DeepSeek: Clear API Key",

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -1,6 +1,6 @@
 {
   "deepseek-copilot.displayName": "DeepSeek V4 for Copilot Chat",
-  "deepseek-copilot.description": "在 Copilot Chat 模型选择器中使用 DeepSeek V4 Pro & Flash。支持视觉识别、思考模式、智能体工具 —— 无需配置，自带密钥。",
+  "deepseek-copilot.description": "在 Copilot Chat 模型选择器中使用 DeepSeek V4 Pro & Flash。支持视觉识别、思考模式、智能体工具。需自行提供 API Key。",
   "deepseek-copilot.providerDisplayName": "DeepSeek",
   "deepseek-copilot.command.setApiKey": "DeepSeek: 设置 API Key",
   "deepseek-copilot.command.getApiKey": "DeepSeek: 获取 API Key",

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -1,0 +1,22 @@
+{
+  "deepseek-copilot.command.setApiKey": "DeepSeek: 设置 API Key",
+  "deepseek-copilot.command.getApiKey": "DeepSeek: 获取 API Key",
+  "deepseek-copilot.command.clearApiKey": "DeepSeek: 清除 API Key",
+  "deepseek-copilot.command.setVisionModel": "DeepSeek: 设置视觉代理模型",
+  "deepseek-copilot.command.openSettings": "DeepSeek: 打开设置",
+  "deepseek-copilot.command.showLogs": "DeepSeek: 显示日志",
+  "deepseek-copilot.walkthrough.title": "DeepSeek V4 for Copilot Chat",
+  "deepseek-copilot.walkthrough.description": "在 Copilot Chat 中配置 DeepSeek V4 模型。",
+  "deepseek-copilot.walkthrough.setApiKey.title": "设置你的 DeepSeek API Key",
+  "deepseek-copilot.walkthrough.setApiKey.description": "从 deepseek.com [获取 API Key](command:deepseek-copilot.getApiKey)。\n[设置 API Key](command:deepseek-copilot.setApiKey)",
+  "deepseek-copilot.walkthrough.showModels.title": "显示 DeepSeek 模型",
+  "deepseek-copilot.walkthrough.showModels.description": "如果模型被隐藏，打开 VS Code 的语言模型管理器并显示 DeepSeek 模型。\n[打开语言模型管理](command:workbench.action.chat.manage)",
+  "deepseek-copilot.config.title": "DeepSeek 助手",
+  "deepseek-copilot.config.baseUrl.description": "DeepSeek API 基础 URL，默认为官方 DeepSeek API 端点。",
+  "deepseek-copilot.config.maxTokens.description": "每次请求的最大输出 Token 数，设为 0 则不限制，可用于控制成本。",
+  "deepseek-copilot.config.modelIdOverrides.description": "覆盖各 DeepSeek 模型实际使用的 API 模型 ID，默认使用官方 DeepSeek ID，仅在对接不同模型名称的第三方 API 时需要修改。",
+  "deepseek-copilot.config.modelIdOverrides.deepseek-v4-flash.description": "DeepSeek V4 Flash 的 API 模型 ID。",
+  "deepseek-copilot.config.modelIdOverrides.deepseek-v4-pro.description": "DeepSeek V4 Pro 的 API 模型 ID。",
+  "deepseek-copilot.config.visionModel.description": "用于描述图片的视觉代理模型 ID，留空则自动检测，也可通过「DeepSeek: 设置视觉代理模型」命令从列表中选择。",
+  "deepseek-copilot.config.visionPrompt.description": "在将图片附件转发给 DeepSeek 之前，发送给视觉代理模型的提示词。"
+}

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -18,5 +18,6 @@
   "deepseek-copilot.config.modelIdOverrides.deepseek-v4-flash.description": "DeepSeek V4 Flash 的 API 模型 ID。",
   "deepseek-copilot.config.modelIdOverrides.deepseek-v4-pro.description": "DeepSeek V4 Pro 的 API 模型 ID。",
   "deepseek-copilot.config.visionModel.description": "用于描述图片的视觉代理模型 ID，留空则自动检测，也可通过「DeepSeek: 设置视觉代理模型」命令从列表中选择。",
-  "deepseek-copilot.config.visionPrompt.description": "在将图片附件转发给 DeepSeek 之前，发送给视觉代理模型的提示词。"
+  "deepseek-copilot.config.visionPrompt.description": "在将图片附件转发给 DeepSeek 之前，发送给视觉代理模型的提示词。",
+  "deepseek-copilot.config.visionPrompt.default": "Describe the visual contents of this image in detail, including any text, objects, people, or context that would be relevant for understanding it. Focus on factual visual elements."
 }

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -1,4 +1,7 @@
 {
+  "deepseek-copilot.displayName": "DeepSeek V4 for Copilot Chat",
+  "deepseek-copilot.description": "在 Copilot Chat 模型选择器中使用 DeepSeek V4 Pro & Flash。支持视觉识别、思考模式、智能体工具 —— 无需配置，自带密钥。",
+  "deepseek-copilot.providerDisplayName": "DeepSeek",
   "deepseek-copilot.command.setApiKey": "DeepSeek: 设置 API Key",
   "deepseek-copilot.command.getApiKey": "DeepSeek: 获取 API Key",
   "deepseek-copilot.command.clearApiKey": "DeepSeek: 清除 API Key",

--- a/resources/walkthrough/set-api-key.nls.zh-cn.md
+++ b/resources/walkthrough/set-api-key.nls.zh-cn.md
@@ -1,0 +1,8 @@
+DeepSeek V4 for Copilot Chat 使用你自己的 DeepSeek API Key，让 Flash 和 Pro 模型出现在模型选择器中。
+
+只需粘贴一次，之后可通过命令面板更新或移除。
+
+- `Cmd/Ctrl + Shift + P`：打开命令面板
+- `DeepSeek: Set API Key`：设置或更新 API Key
+- `DeepSeek: Clear API Key`：移除 API Key
+- `DeepSeek: Get API Key`：创建 DeepSeek API Key

--- a/resources/walkthrough/show-models.nls.zh-cn.md
+++ b/resources/walkthrough/show-models.nls.zh-cn.md
@@ -1,0 +1,3 @@
+扩展激活后，DeepSeek 模型应立即出现在 Copilot 模型选择器中。如果尚未配置 API Key，模型会显示警告图标，直到你运行 DeepSeek: Set API Key 为止。
+
+如果没有立即看到，可能只是模型列表较长。在选取器中向下滚动，查找 DeepSeek V4 Flash 和 Pro。

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,5 +1,6 @@
 import vscode from 'vscode';
 import { API_KEY_SECRET } from './consts';
+import { t } from './i18n';
 
 /**
  * Manages DeepSeek API key via VS Code SecretStorage (secure) with
@@ -57,16 +58,16 @@ export class AuthManager {
 	 */
 	async promptForApiKey(): Promise<boolean> {
 		const apiKey = await vscode.window.showInputBox({
-			prompt: 'Enter your DeepSeek API key',
-			placeHolder: 'sk-...',
+			prompt: t('auth.prompt'),
+			placeHolder: t('auth.placeholder'),
 			password: true,
 			ignoreFocusOut: true,
 			validateInput: (value: string) => {
 				if (!value?.trim()) {
-					return 'API key cannot be empty';
+					return t('auth.emptyValidation');
 				}
 				if (!value.startsWith('sk-')) {
-					return 'API key should start with "sk-"';
+					return t('auth.prefixValidation');
 				}
 				return undefined;
 			},
@@ -74,7 +75,7 @@ export class AuthManager {
 
 		if (apiKey) {
 			await this.setApiKey(apiKey);
-			vscode.window.showInformationMessage('DeepSeek API key saved securely.');
+			vscode.window.showInformationMessage(t('auth.saved'));
 			return true;
 		}
 

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -35,6 +35,13 @@ export const DEFAULT_VISION_MODEL_ID = 'oswe-vscode-prime';
 export const IMAGE_DESCRIPTION_PROMPT =
 	'Describe the visual contents of this image in detail, including any text, objects, people, or context that would be relevant for understanding it. Focus on factual visual elements.';
 
+/**
+ * Stable fallback marker inserted into the chat prompt when the vision proxy
+ * fails to describe an image. Keep this in English and out of i18n so prompt
+ * shape and cache behaviour do not vary by VS Code display language.
+ */
+export const IMAGE_DESCRIPTION_UNAVAILABLE = '[Image Description unavailable]';
+
 // ---- Cache ----
 
 /** Max entries in the reasoning-content cache before eviction kicks in. */

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -23,30 +23,6 @@ export const WELCOME_SHOWN_KEY = 'deepseek-copilot.welcomeShown';
 /** Walkthrough contribution ID. */
 export const WALKTHROUGH_ID = 'Vizards.deepseek-v4-for-copilot#deepseekGettingStarted';
 
-// ---- Model picker ----
-
-/** Detail text shown in the model picker when no API key is configured. */
-export const API_KEY_REQUIRED_DETAIL = 'Please run DeepSeek: Set API Key to configure.';
-
-/** Per-model configuration schema consumed by Copilot Chat's model picker. */
-export const THINKING_EFFORT_CONFIGURATION_SCHEMA = {
-	properties: {
-		reasoningEffort: {
-			type: 'string',
-			title: 'Thinking Effort',
-			enum: ['none', 'high', 'max'],
-			enumItemLabels: ['None', 'High', 'Max'],
-			enumDescriptions: [
-				'Disable thinking for faster responses',
-				'Recommended for most tasks',
-				'Maximum reasoning depth for complex agent tasks',
-			],
-			default: 'high',
-			group: 'navigation',
-		},
-	},
-} as const;
-
 // ---- Vision proxy ----
 
 /** Default model ID used for the vision proxy when auto-detection is enabled. */

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,6 @@
 import vscode from 'vscode';
 import { WALKTHROUGH_ID, WELCOME_SHOWN_KEY } from './consts';
+import { t } from './i18n';
 import { logger } from './logger';
 import { DeepSeekChatProvider } from './provider';
 
@@ -53,16 +54,14 @@ export function activate(context: vscode.ExtensionContext) {
 		provider.refreshModelPicker();
 
 		void showWelcomeIfNeeded(context, provider).catch((error) => {
-			logger.warn('Failed to show DeepSeek welcome prompt', error);
+			logger.warn(t('extension.welcomeFailed'), error);
 		});
 
 		logger.info('Extension activated');
 	} catch (error) {
 		activeProvider = undefined;
 		logger.error('Failed to activate DeepSeek extension', error);
-		void vscode.window.showErrorMessage(
-			'DeepSeek failed to activate. Run "DeepSeek: Show Logs" for details.',
-		);
+		void vscode.window.showErrorMessage(t('extension.activateFailed'));
 		throw error;
 	}
 }
@@ -87,7 +86,7 @@ export async function deactivate() {
 	try {
 		await activeProvider?.prepareForDeactivate();
 	} catch (error) {
-		logger.warn('Failed to prepare DeepSeek provider for deactivate', error);
+		logger.warn(t('extension.deactivateFailed'), error);
 	} finally {
 		activeProvider = undefined;
 		logger.info('Extension deactivated');

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -113,9 +113,9 @@ export function t(key: string, ...args: (string | number)[]): string {
 	if (text === undefined) {
 		return key;
 	}
-	// Replace positional placeholders.
+	// Replace all occurrences of each positional placeholder.
 	for (let i = 0; i < args.length; i++) {
-		text = text.replace(`{${i}}`, String(args[i]));
+		text = text.replaceAll(`{${i}}`, String(args[i]));
 	}
 	return text;
 }

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,0 +1,118 @@
+import vscode from 'vscode';
+
+/**
+ * Lightweight i18n module — zero dependencies, follows VS Code display language.
+ *
+ *  - en / en-US / en-* → English (default)
+ *  - zh-cn / zh / zh-*   → Simplified Chinese
+ */
+
+function isZh(): boolean {
+	const lang = vscode.env.language.toLowerCase();
+	return lang === 'zh-cn' || lang === 'zh' || lang.startsWith('zh-');
+}
+
+// ---- Translation dictionaries ----
+
+type Translations = Record<string, string>;
+
+const zh: Translations = {
+	// Model descriptions
+	'model.flash.detail': '快速高效',
+	'model.pro.detail': '深度推理',
+
+	// API Key
+	'auth.apiKeyRequiredDetail': '请先配置 API Key',
+	'auth.prompt': '请输入 DeepSeek API Key',
+	'auth.placeholder': 'sk-...',
+	'auth.emptyValidation': 'API Key 不能为空',
+	'auth.prefixValidation': 'API Key 应以 "sk-" 开头',
+	'auth.saved': 'API Key 已安全保存。',
+	'auth.removed': 'API Key 已移除。',
+	'auth.notConfigured': 'API Key 未配置，请在命令面板运行 "DeepSeek: 设置 API Key"。',
+
+	// Thinking Effort — short labels for model picker dropdown
+	'status.thinking': '思考模式',
+	'thinking.none': '停用',
+	'thinking.none.desc': '停用思考，响应更快',
+	'thinking.high': '标准',
+	'thinking.high.desc': '推荐日常使用',
+	'thinking.max': '深度',
+	'thinking.max.desc': '深度推理，适合复杂任务',
+
+	// Vision
+	'vision.noModel': '当前环境中无可用的语言模型。',
+	'vision.pickPlaceholder': '选择用于描述图片的模型 (默认 {0})',
+	'vision.current': '当前',
+	'vision.proxyUsing': '视觉代理：{0}',
+	'vision.notFound': '未找到视觉模型 "{0}"',
+	'vision.unavailable': '无可用视觉模型，图片已忽略。',
+	'vision.proxyError': '视觉代理异常：',
+	'vision.unableToDescribe': '[图片无法识别]',
+
+	// Extension
+	'extension.activateFailed': 'DeepSeek 激活失败，请运行 "DeepSeek: 显示日志" 查看详情。',
+	'extension.deactivateFailed': 'DeepSeek 停用异常',
+	'extension.welcomeFailed': '欢迎引导加载异常',
+};
+
+const en: Translations = {
+	// Model descriptions
+	'model.flash.detail': 'Fast, general-purpose model',
+	'model.pro.detail': 'Most capable reasoning model',
+
+	// API Key
+	'auth.apiKeyRequiredDetail': 'Please run DeepSeek: Set API Key to configure.',
+	'auth.prompt': 'Enter your DeepSeek API key',
+	'auth.placeholder': 'sk-...',
+	'auth.emptyValidation': 'API key cannot be empty',
+	'auth.prefixValidation': 'API key should start with "sk-"',
+	'auth.saved': 'DeepSeek API key saved.',
+	'auth.removed': 'DeepSeek API key removed.',
+	'auth.notConfigured': 'DeepSeek API key not configured. Run "DeepSeek: Set API Key" from the Command Palette.',
+
+	// Thinking Effort
+	'status.thinking': 'Thinking Effort',
+	'thinking.none': 'None',
+	'thinking.none.desc': 'Disable thinking for faster responses',
+	'thinking.high': 'High',
+	'thinking.high.desc': 'Recommended for most tasks',
+	'thinking.max': 'Max',
+	'thinking.max.desc': 'Maximum reasoning depth for complex agent tasks',
+
+	// Vision
+	'vision.noModel': 'No language models available in the current environment',
+	'vision.pickPlaceholder': 'Select a model for image description (default: {0})',
+	'vision.current': 'Current',
+	'vision.proxyUsing': 'Vision proxy: {0}',
+	'vision.notFound': 'Vision model "{0}" not found',
+	'vision.unavailable': 'No vision models available, image(s) ignored',
+	'vision.proxyError': 'Vision proxy error:',
+	'vision.unableToDescribe': '[Unable to describe image]',
+
+	// Extension
+	'extension.activateFailed': 'DeepSeek failed to activate. Run "DeepSeek: Show Logs" for details.',
+	'extension.deactivateFailed': 'Failed to prepare DeepSeek provider for deactivate',
+	'extension.welcomeFailed': 'Failed to show DeepSeek welcome prompt',
+};
+
+/**
+ * Resolve a translation key for the current VS Code display language.
+ * Supports positional placeholders {0}, {1}, ...
+ */
+export function t(key: string, ...args: (string | number)[]): string {
+	const dict = isZh() ? zh : en;
+	let text = dict[key];
+	if (text === undefined) {
+		// Fall back to English when a key is missing from the active locale.
+		text = en[key];
+	}
+	if (text === undefined) {
+		return key;
+	}
+	// Replace positional placeholders.
+	for (let i = 0; i < args.length; i++) {
+		text = text.replace(`{${i}}`, String(args[i]));
+	}
+	return text;
+}

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -3,13 +3,14 @@ import vscode from 'vscode';
 /**
  * Lightweight i18n module — zero dependencies, follows VS Code display language.
  *
- *  - en / en-US / en-* → English (default)
- *  - zh-cn / zh / zh-*   → Simplified Chinese
+ *  - en / en-US / en-*      → English (default)
+ *  - zh-cn / zh-hans / zh   → Simplified Chinese
+ *  - other zh-* locales     → English until translated
  */
 
 function isZh(): boolean {
 	const lang = vscode.env.language.toLowerCase();
-	return lang === 'zh-cn' || lang === 'zh' || lang.startsWith('zh-');
+	return lang === 'zh-cn' || lang === 'zh-hans' || lang === 'zh';
 }
 
 // ---- Translation dictionaries ----

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -70,7 +70,8 @@ const en: Translations = {
 	'auth.prefixValidation': 'API key should start with "sk-"',
 	'auth.saved': 'DeepSeek API key saved.',
 	'auth.removed': 'DeepSeek API key removed.',
-	'auth.notConfigured': 'DeepSeek API key not configured. Run "DeepSeek: Set API Key" from the Command Palette.',
+	'auth.notConfigured':
+		'DeepSeek API key not configured. Run "DeepSeek: Set API Key" from the Command Palette.',
 
 	// Thinking Effort
 	'status.thinking': 'Thinking Effort',

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -50,7 +50,7 @@ const zh: Translations = {
 	'vision.notFound': '未找到视觉模型 "{0}"',
 	'vision.unavailable': '无可用视觉模型，图片已忽略。',
 	'vision.proxyError': '视觉代理异常：',
-	'vision.unableToDescribe': '[图片无法识别]',
+	'vision.unableToDescribe': '[Image Description unavailable]',
 
 	// Extension
 	'extension.activateFailed': 'DeepSeek 激活失败，请运行 "DeepSeek: 显示日志" 查看详情。',
@@ -83,6 +83,9 @@ const en: Translations = {
 	'thinking.max.desc': 'Maximum reasoning depth for complex agent tasks',
 
 	// Vision
+	// NOTE: vision.unableToDescribe is inserted into LanguageModelTextPart
+	// (prompt content sent to the chat model). Keep the value stable in
+	// English across all locales to avoid affecting model behaviour.
 	'vision.vendorLabel': 'vendor: {0}',
 	'vision.noModel': 'No language models available in the current environment',
 	'vision.pickPlaceholder': 'Select a model for image description (default: {0})',
@@ -91,7 +94,7 @@ const en: Translations = {
 	'vision.notFound': 'Vision model "{0}" not found',
 	'vision.unavailable': 'No vision models available, image(s) ignored',
 	'vision.proxyError': 'Vision proxy error:',
-	'vision.unableToDescribe': '[Unable to describe image]',
+	'vision.unableToDescribe': '[Image Description unavailable]',
 
 	// Extension
 	'extension.activateFailed': 'DeepSeek failed to activate. Run "DeepSeek: Show Logs" for details.',

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -42,7 +42,7 @@ const zh: Translations = {
 	'thinking.max.desc': '深度推理，适合复杂任务',
 
 	// Vision
-	'vision.vendorLabel': 'vendor: {0}',
+	'vision.vendorLabel': '提供商：{0}',
 	'vision.noModel': '当前环境中无可用的语言模型。',
 	'vision.pickPlaceholder': '选择用于描述图片的模型 (默认 {0})',
 	'vision.current': '当前',
@@ -50,7 +50,6 @@ const zh: Translations = {
 	'vision.notFound': '未找到视觉模型 "{0}"',
 	'vision.unavailable': '无可用视觉模型，图片已忽略。',
 	'vision.proxyError': '视觉代理异常：',
-	'vision.unableToDescribe': '[Image Description unavailable]',
 
 	// Extension
 	'extension.activateFailed': 'DeepSeek 激活失败，请运行 "DeepSeek: 显示日志" 查看详情。',
@@ -83,9 +82,8 @@ const en: Translations = {
 	'thinking.max.desc': 'Maximum reasoning depth for complex agent tasks',
 
 	// Vision
-	// NOTE: vision.unableToDescribe is inserted into LanguageModelTextPart
-	// (prompt content sent to the chat model). Keep the value stable in
-	// English across all locales to avoid affecting model behaviour.
+	// NOTE: vision.unableToDescribe has been moved to consts.ts as
+	// IMAGE_DESCRIPTION_UNAVAILABLE — it is prompt content, not UI text.
 	'vision.vendorLabel': 'vendor: {0}',
 	'vision.noModel': 'No language models available in the current environment',
 	'vision.pickPlaceholder': 'Select a model for image description (default: {0})',
@@ -94,7 +92,6 @@ const en: Translations = {
 	'vision.notFound': 'Vision model "{0}" not found',
 	'vision.unavailable': 'No vision models available, image(s) ignored',
 	'vision.proxyError': 'Vision proxy error:',
-	'vision.unableToDescribe': '[Image Description unavailable]',
 
 	// Extension
 	'extension.activateFailed': 'DeepSeek failed to activate. Run "DeepSeek: Show Logs" for details.',

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -41,6 +41,7 @@ const zh: Translations = {
 	'thinking.max.desc': '深度推理，适合复杂任务',
 
 	// Vision
+	'vision.vendorLabel': 'vendor: {0}',
 	'vision.noModel': '当前环境中无可用的语言模型。',
 	'vision.pickPlaceholder': '选择用于描述图片的模型 (默认 {0})',
 	'vision.current': '当前',
@@ -81,6 +82,7 @@ const en: Translations = {
 	'thinking.max.desc': 'Maximum reasoning depth for complex agent tasks',
 
 	// Vision
+	'vision.vendorLabel': 'vendor: {0}',
 	'vision.noModel': 'No language models available in the current environment',
 	'vision.pickPlaceholder': 'Select a model for image description (default: {0})',
 	'vision.current': 'Current',

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -4,13 +4,13 @@ import vscode from 'vscode';
  * Lightweight i18n module — zero dependencies, follows VS Code display language.
  *
  *  - en / en-US / en-*      → English (default)
- *  - zh-cn / zh-hans / zh   → Simplified Chinese
- *  - other zh-* locales     → English until translated
+ *  - zh-cn                  → Simplified Chinese
+ *  - all other locales      → English until translated
  */
 
 function isZh(): boolean {
 	const lang = vscode.env.language.toLowerCase();
-	return lang === 'zh-cn' || lang === 'zh-hans' || lang === 'zh';
+	return lang === 'zh-cn';
 }
 
 // ---- Translation dictionaries ----

--- a/src/provider/index.ts
+++ b/src/provider/index.ts
@@ -2,7 +2,8 @@ import vscode from 'vscode';
 import { AuthManager } from '../auth';
 import { DeepSeekClient } from '../client';
 import { getApiModelId, getBaseUrl, getMaxTokens } from '../config';
-import { API_KEY_REQUIRED_DETAIL, MODELS, THINKING_EFFORT_CONFIGURATION_SCHEMA } from '../consts';
+import { MODELS } from '../consts';
+import { t } from '../i18n';
 import { logger } from '../logger';
 import type { DeepSeekToolCall, ModelDefinition } from '../types';
 import { type ReasoningEntry, pruneReasoningCache } from './cache';
@@ -41,10 +42,13 @@ type ModelConfigurationOptions = vscode.ProvideLanguageModelChatResponseOptions 
  * `statusIcon` renders a leading icon (e.g. warning when key missing), and
  * `configurationSchema` declares the per-model dropdown schema.
  */
+/** Shape of the per-model configuration schema rendered by Copilot Chat's model picker. */
+type ThinkingEffortConfigurationSchema = ReturnType<typeof buildThinkingEffortSchema>;
+
 type ModelPickerChatInformation = vscode.LanguageModelChatInformation & {
 	readonly isUserSelectable: boolean;
 	readonly statusIcon?: vscode.ThemeIcon;
-	readonly configurationSchema?: typeof THINKING_EFFORT_CONFIGURATION_SCHEMA;
+	readonly configurationSchema?: ThinkingEffortConfigurationSchema;
 };
 
 /**
@@ -112,7 +116,7 @@ export class DeepSeekChatProvider implements vscode.LanguageModelChatProvider {
 	async clearApiKey(): Promise<void> {
 		await this.authManager.deleteApiKey();
 		this.onDidChangeLanguageModelChatInformationEmitter.fire();
-		vscode.window.showInformationMessage('DeepSeek API key removed.');
+		vscode.window.showInformationMessage(t('auth.removed'));
 	}
 
 	async hasApiKey(): Promise<boolean> {
@@ -168,9 +172,7 @@ export class DeepSeekChatProvider implements vscode.LanguageModelChatProvider {
 	): Promise<void> {
 		const apiKey = await this.authManager.getApiKey();
 		if (!apiKey) {
-			throw new Error(
-				'DeepSeek API key not configured. Run "DeepSeek: Set API Key" from the Command Palette.',
-			);
+			throw new Error(t('auth.notConfigured'));
 		}
 
 		const baseUrl = getBaseUrl();
@@ -328,14 +330,39 @@ export class DeepSeekChatProvider implements vscode.LanguageModelChatProvider {
 
 // ---- Helpers ----
 
+/**
+ * Build the thinking effort configuration schema with translated labels.
+ * Called inside toChatInfo() so translations reflect the current locale.
+ */
+function buildThinkingEffortSchema() {
+	return {
+		properties: {
+			reasoningEffort: {
+				type: 'string',
+				title: t('status.thinking'),
+				enum: ['none', 'high', 'max'],
+				enumItemLabels: [t('thinking.none'), t('thinking.high'), t('thinking.max')],
+				enumDescriptions: [
+					t('thinking.none.desc'),
+					t('thinking.high.desc'),
+					t('thinking.max.desc'),
+				],
+				default: 'high',
+				group: 'navigation',
+			},
+		},
+	} as const;
+}
+
 function toChatInfo(m: ModelDefinition, hasApiKey: boolean): ModelPickerChatInformation {
+	const modelDetail = m.id === 'deepseek-v4-flash' ? t('model.flash.detail') : t('model.pro.detail');
 	return {
 		id: m.id,
 		name: m.name,
 		family: m.family,
 		version: m.version,
-		detail: hasApiKey ? m.detail : API_KEY_REQUIRED_DETAIL,
-		tooltip: hasApiKey ? undefined : API_KEY_REQUIRED_DETAIL,
+		detail: hasApiKey ? modelDetail : t('auth.apiKeyRequiredDetail'),
+		tooltip: hasApiKey ? undefined : t('auth.apiKeyRequiredDetail'),
 		statusIcon: hasApiKey ? undefined : new vscode.ThemeIcon('warning'),
 		maxInputTokens: m.maxInputTokens,
 		maxOutputTokens: m.maxOutputTokens,
@@ -345,7 +372,7 @@ function toChatInfo(m: ModelDefinition, hasApiKey: boolean): ModelPickerChatInfo
 			imageInput: m.capabilities.imageInput,
 		},
 		...(m.capabilities.thinking
-			? { configurationSchema: THINKING_EFFORT_CONFIGURATION_SCHEMA }
+			? { configurationSchema: buildThinkingEffortSchema() }
 			: {}),
 	};
 }

--- a/src/provider/index.ts
+++ b/src/provider/index.ts
@@ -354,8 +354,24 @@ function buildThinkingEffortSchema() {
 	} as const;
 }
 
+/**
+ * Derive the i18n key for a model's detail line from the model ID.
+ * Falls back to `undefined` for unknown models — `toChatInfo()` will
+ * use the untranslated `m.detail` from the model registry in that case.
+ */
+function resolveDetailKey(m: ModelDefinition): string | undefined {
+	// Map known DeepSeek V4 models: deepseek-v4-flash → model.flash.detail
+	const suffix = m.id.startsWith('deepseek-v4-') ? m.id.slice('deepseek-v4-'.length) : m.id;
+	const key = `model.${suffix}.detail`;
+	// t() returns the raw key string when no translation is defined in either
+	// locale — treat that as "no translation available" and fall back.
+	const translated = t(key);
+	return translated !== key ? key : undefined;
+}
+
 function toChatInfo(m: ModelDefinition, hasApiKey: boolean): ModelPickerChatInformation {
-	const modelDetail = m.id === 'deepseek-v4-flash' ? t('model.flash.detail') : t('model.pro.detail');
+	const detailKey = resolveDetailKey(m);
+	const modelDetail = detailKey ? t(detailKey) : m.detail;
 	return {
 		id: m.id,
 		name: m.name,

--- a/src/provider/index.ts
+++ b/src/provider/index.ts
@@ -356,8 +356,10 @@ function buildThinkingEffortSchema() {
 
 /**
  * Derive the i18n key for a model's detail line from the model ID.
- * Falls back to `undefined` for unknown models — `toChatInfo()` will
- * use the untranslated `m.detail` from the model registry in that case.
+ * Returns `undefined` when the key is missing from *both* locales —
+ * `toChatInfo()` will then fall back to `m.detail`. When the key exists
+ * in English but not the active locale, the English translation is used
+ * (per `t()`'s fallback behaviour).
  */
 function resolveDetailKey(m: ModelDefinition): string | undefined {
 	// Map known DeepSeek V4 models: deepseek-v4-flash → model.flash.detail

--- a/src/provider/index.ts
+++ b/src/provider/index.ts
@@ -389,9 +389,7 @@ function toChatInfo(m: ModelDefinition, hasApiKey: boolean): ModelPickerChatInfo
 			toolCalling: m.capabilities.toolCalling,
 			imageInput: m.capabilities.imageInput,
 		},
-		...(m.capabilities.thinking
-			? { configurationSchema: buildThinkingEffortSchema() }
-			: {}),
+		...(m.capabilities.thinking ? { configurationSchema: buildThinkingEffortSchema() } : {}),
 	};
 }
 

--- a/src/provider/vision.ts
+++ b/src/provider/vision.ts
@@ -1,5 +1,9 @@
 import vscode from 'vscode';
-import { DEFAULT_VISION_MODEL_ID, IMAGE_DESCRIPTION_PROMPT, IMAGE_DESCRIPTION_UNAVAILABLE } from '../consts';
+import {
+	DEFAULT_VISION_MODEL_ID,
+	IMAGE_DESCRIPTION_PROMPT,
+	IMAGE_DESCRIPTION_UNAVAILABLE,
+} from '../consts';
 import { t } from '../i18n';
 import { logger } from '../logger';
 

--- a/src/provider/vision.ts
+++ b/src/provider/vision.ts
@@ -1,5 +1,5 @@
 import vscode from 'vscode';
-import { DEFAULT_VISION_MODEL_ID, IMAGE_DESCRIPTION_PROMPT } from '../consts';
+import { DEFAULT_VISION_MODEL_ID, IMAGE_DESCRIPTION_PROMPT, IMAGE_DESCRIPTION_UNAVAILABLE } from '../consts';
 import { t } from '../i18n';
 import { logger } from '../logger';
 
@@ -70,7 +70,7 @@ export async function resolveImageMessages(
 			);
 		} catch (err) {
 			logger.error(t('vision.proxyError'), err);
-			otherParts.push(new vscode.LanguageModelTextPart(t('vision.unableToDescribe')));
+			otherParts.push(new vscode.LanguageModelTextPart(IMAGE_DESCRIPTION_UNAVAILABLE));
 		}
 
 		result.push({

--- a/src/provider/vision.ts
+++ b/src/provider/vision.ts
@@ -1,5 +1,6 @@
 import vscode from 'vscode';
 import { DEFAULT_VISION_MODEL_ID, IMAGE_DESCRIPTION_PROMPT } from '../consts';
+import { t } from '../i18n';
 import { logger } from '../logger';
 
 /**
@@ -19,7 +20,7 @@ export async function resolveImageMessages(
 
 	const visionModel = await getModel();
 	if (!visionModel) {
-		logger.warn('No vision model available; images will be dropped.');
+		logger.warn(t('vision.unavailable'));
 		return messages.map((m) => {
 			const filtered = (m.content as readonly vscode.LanguageModelInputPart[]).filter(
 				(p) => !isImageDataPart(p),
@@ -68,8 +69,8 @@ export async function resolveImageMessages(
 				new vscode.LanguageModelTextPart(`[Image Description: ${description.trim()}]`),
 			);
 		} catch (err) {
-			logger.error('Vision proxy error:', err);
-			otherParts.push(new vscode.LanguageModelTextPart('[Image: unable to describe]'));
+			logger.error(t('vision.proxyError'), err);
+			otherParts.push(new vscode.LanguageModelTextPart(t('vision.unableToDescribe')));
 		}
 
 		result.push({
@@ -105,11 +106,11 @@ export function createVisionModelGetter(): {
 				const id = getConfiguredVisionModelId() ?? DEFAULT_VISION_MODEL_ID;
 				const models = await vscode.lm.selectChatModels({ id });
 				if (models.length > 0) {
-					logger.info(`Using vision proxy model: ${models[0].id}`);
+					logger.info(t('vision.proxyUsing', models[0].id));
 					visionModel = models[0];
 					return models[0];
 				}
-				logger.warn(`Vision model "${id}" not found.`);
+				logger.warn(t('vision.notFound', id));
 				return undefined;
 			})();
 
@@ -131,9 +132,7 @@ export async function setVisionProxyModel(): Promise<void> {
 	const candidates = allModels.filter((m) => m.vendor !== 'deepseek');
 
 	if (candidates.length === 0) {
-		vscode.window.showInformationMessage(
-			'No language models available in your VS Code environment.',
-		);
+		vscode.window.showInformationMessage(t('vision.noModel'));
 		return;
 	}
 
@@ -142,11 +141,11 @@ export async function setVisionProxyModel(): Promise<void> {
 	const items = candidates.map((m) => ({
 		label: m.id,
 		description: `vendor: ${m.vendor}`,
-		detail: m.id === currentId ? '✓ current' : undefined,
+		detail: m.id === currentId ? t('vision.current') : undefined,
 	}));
 
 	const picked = await vscode.window.showQuickPick(items, {
-		placeHolder: `Pick a model to describe image attachments (default: ${DEFAULT_VISION_MODEL_ID})`,
+		placeHolder: t('vision.pickPlaceholder', DEFAULT_VISION_MODEL_ID),
 		matchOnDescription: true,
 	});
 

--- a/src/provider/vision.ts
+++ b/src/provider/vision.ts
@@ -140,7 +140,7 @@ export async function setVisionProxyModel(): Promise<void> {
 
 	const items = candidates.map((m) => ({
 		label: m.id,
-		description: `vendor: ${m.vendor}`,
+		description: t('vision.vendorLabel', m.vendor),
 		detail: m.id === currentId ? t('vision.current') : undefined,
 	}));
 


### PR DESCRIPTION
## 变更摘要

为扩展添加简体中文国际化支持，界面语言自动跟随 VS Code 显示语言。

- `package.json` 全部字符串外部化到 `package.nls.json` / `package.nls.zh-cn.json`
- 运行时用户可见文本通过 `src/i18n.ts` + `t()` 翻译
- Thinking Effort 模型选择器下拉、模型描述、命令面板、设置页、API Key 弹窗等均已覆盖
- 零外部依赖，通过 `vscode.env.language` 自动判断语言

## Summary

Add Simplified Chinese (zh-cn) i18n support. UI language automatically follows VS Code's display language.

- Externalized all `package.json` strings to `package.nls.json` / `package.nls.zh-cn.json`
- Wrapped runtime user-facing strings with `src/i18n.ts` + `t()`
- Covers Thinking Effort dropdown, model descriptions, command palette, settings, API key dialog, etc.
- Zero dependencies, driven by `vscode.env.language`

## Verification

- `tsc` compiles with zero errors
- `.vsix` installed and tested locally in both English and Chinese environments