### PR TITLE
Document model ID overrides and clean packaging output

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Both support optional thinking mode, tool calling, and 1M token context.
 |---|---|---|
 | `deepseek-copilot.baseUrl` | `https://api.deepseek.com` | API endpoint — change for self-hosted / proxied deployments |
 | `deepseek-copilot.maxTokens` | `0` | Max output tokens (`0` = no limit). Useful for cost control |
-| `deepseek-copilot.modelIdOverrides` | official DeepSeek IDs | API model IDs to send for DeepSeek V4 Flash / Pro. Change only for compatible third-party APIs with different model names |
+| `deepseek-copilot.modelIdOverrides` | prefilled official ID map | API model IDs to send for DeepSeek V4 Flash / Pro. Change only for compatible third-party APIs with different model names |
 | `deepseek-copilot.visionModel` | *(auto)* | Which Copilot model to proxy images through |
 | `deepseek-copilot.visionPrompt` | *(built-in)* | Prompt used to describe image attachments |
 
@@ -93,9 +93,11 @@ Thinking Effort is configured from Copilot Chat's model picker for each DeepSeek
 Example `settings.json` override for compatible API proxies:
 
 ```json
-"deepseek-copilot.modelIdOverrides": {
-  "deepseek-v4-flash": "your-flash-model-id",
-  "deepseek-v4-pro": "your-pro-model-id"
+{
+  "deepseek-copilot.modelIdOverrides": {
+    "deepseek-v4-flash": "your-flash-model-id",
+    "deepseek-v4-pro": "your-pro-model-id"
+  }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -84,10 +84,20 @@ Both support optional thinking mode, tool calling, and 1M token context.
 |---|---|---|
 | `deepseek-copilot.baseUrl` | `https://api.deepseek.com` | API endpoint — change for self-hosted / proxied deployments |
 | `deepseek-copilot.maxTokens` | `0` | Max output tokens (`0` = no limit). Useful for cost control |
+| `deepseek-copilot.modelIdOverrides` | official DeepSeek IDs | API model IDs to send for DeepSeek V4 Flash / Pro. Change only for compatible third-party APIs with different model names |
 | `deepseek-copilot.visionModel` | *(auto)* | Which Copilot model to proxy images through |
 | `deepseek-copilot.visionPrompt` | *(built-in)* | Prompt used to describe image attachments |
 
 Thinking Effort is configured from Copilot Chat's model picker for each DeepSeek model.
+
+Example `settings.json` override for compatible API proxies:
+
+```json
+"deepseek-copilot.modelIdOverrides": {
+  "deepseek-v4-flash": "your-flash-model-id",
+  "deepseek-v4-pro": "your-pro-model-id"
+}
+```
 
 ## Compared to alternatives
 

--- a/package.json
+++ b/package.json
@@ -154,7 +154,8 @@
     }
   },
   "scripts": {
-    "vscode:prepublish": "npm run compile",
+    "clean": "node -e \"require('node:fs').rmSync('out', { recursive: true, force: true, maxRetries: process.platform === 'win32' ? 10 : 0 })\"",
+    "vscode:prepublish": "npm run clean && npm run compile",
     "compile": "tsc -p ./",
     "watch": "tsc -watch -p ./",
     "lint": "oxlint",


### PR DESCRIPTION
## Summary
- Document `deepseek-copilot.modelIdOverrides` in the README settings table with a `settings.json` example for compatible API proxies.
- Run `clean` before `compile` during `vscode:prepublish` so stale `out/` files are not packaged.
- Use Node's native `fs.rmSync` for the clean script instead of adding an extra dependency.

## Validation
- `npm run format:check`
- `npm run lint`
- `npm run package`