### PR TITLE
Remove stale vision fallback configuration listener

### DIFF
--- a/src/provider/index.ts
+++ b/src/provider/index.ts
@@ -82,10 +82,7 @@ export class DeepSeekChatProvider implements vscode.LanguageModelChatProvider {
 					this.onDidChangeLanguageModelChatInformationEmitter.fire();
 				}
 
-				if (
-					e.affectsConfiguration('deepseek-copilot.visionModel') ||
-					e.affectsConfiguration('deepseek-copilot.visionFallbackIds')
-				) {
+				if (e.affectsConfiguration('deepseek-copilot.visionModel')) {
 					this.vision.reset();
 				}
 			}),


### PR DESCRIPTION
## Summary
- Remove the obsolete `deepseek-copilot.visionFallbackIds` configuration change listener.
- Keep the existing `visionModel` reset path, which is the only vision configuration currently contributed and read.

## Validation
- `npm run format:check`
- `npm run lint`
- `npm run package`