### PR TITLE
chore(debug): add product-specific extension host configs

### DIFF
--- a/.vscode/launch-extension-host.ps1
+++ b/.vscode/launch-extension-host.ps1
@@ -46,13 +46,35 @@ try {
   $connections = @()
 }
 
+function Test-PortListening {
+  try {
+    return [bool](Get-NetTCPConnection -LocalPort $Port -State Listen -ErrorAction SilentlyContinue)
+  } catch {
+    return $false
+  }
+}
+
+function Wait-ForPortRelease {
+  for ($attempt = 0; $attempt -lt 10; $attempt++) {
+    if (-not (Test-PortListening)) {
+      return
+    }
+    Start-Sleep -Milliseconds 200
+  }
+
+  [Console]::Error.WriteLine("Port $Port is still in use after stopping stale extension host processes.")
+  exit 1
+}
+
 $processIds = @($connections | ForEach-Object { $_.OwningProcess } | Where-Object { $_ } | Sort-Object -Unique)
+$stoppedProcess = $false
 
 foreach ($processId in $processIds) {
   $commandLine = Get-ProcessCommandLine -ProcessId $processId
 
   if ([string]::IsNullOrWhiteSpace($commandLine)) {
-    continue
+    [Console]::Error.WriteLine("Port $Port is already used by PID $processId, but its command line could not be inspected.`nRefusing to stop it automatically.")
+    exit 1
   }
 
   $isExtensionHost = $commandLine -like "*--inspect=127.0.0.1:$Port*" `
@@ -62,11 +84,16 @@ foreach ($processId in $processIds) {
 
   if ($isExtensionHost) {
     Stop-Process -Id $processId -Force -ErrorAction SilentlyContinue
+    $stoppedProcess = $true
     continue
   }
 
   [Console]::Error.WriteLine("Port $Port is already used by PID $processId, but it does not look like a VS Code extension host:`n$commandLine`nRefusing to stop it automatically.")
   exit 1
+}
+
+if ($stoppedProcess) {
+  Wait-ForPortRelease
 }
 
 & $cli `

--- a/.vscode/launch-extension-host.ps1
+++ b/.vscode/launch-extension-host.ps1
@@ -1,0 +1,80 @@
+param(
+  [Parameter(Mandatory = $true)]
+  [ValidateSet("stable", "insiders")]
+  [string] $Quality,
+
+  [Parameter(Mandatory = $true)]
+  [int] $Port,
+
+  [Parameter(Mandatory = $true)]
+  [string] $Workspace
+)
+
+$ErrorActionPreference = "Stop"
+
+switch ($Quality) {
+  "stable" {
+    $cli = "code"
+    $installHint = "Shell Command: Install 'code' command in PATH"
+  }
+  "insiders" {
+    $cli = "code-insiders"
+    $installHint = "Shell Command: Install 'code-insiders' command in PATH"
+  }
+}
+
+if (-not (Get-Command $cli -ErrorAction SilentlyContinue)) {
+  [Console]::Error.WriteLine("Missing '$cli' in PATH.`nInstall it from the target VS Code Command Palette:`n  $installHint`nThen restart the terminal and try again.")
+  exit 127
+}
+
+function Get-ProcessCommandLine {
+  param([int] $ProcessId)
+
+  try {
+    $processInfo = Get-CimInstance Win32_Process -Filter "ProcessId = $ProcessId"
+    return $processInfo.CommandLine
+  } catch {
+    return ""
+  }
+}
+
+try {
+  $connections = @(Get-NetTCPConnection -LocalPort $Port -State Listen -ErrorAction SilentlyContinue)
+} catch {
+  Write-Warning "Get-NetTCPConnection is unavailable; skipping stale inspector cleanup for port $Port."
+  $connections = @()
+}
+
+$processIds = @($connections | ForEach-Object { $_.OwningProcess } | Where-Object { $_ } | Sort-Object -Unique)
+
+foreach ($processId in $processIds) {
+  $commandLine = Get-ProcessCommandLine -ProcessId $processId
+
+  if ([string]::IsNullOrWhiteSpace($commandLine)) {
+    continue
+  }
+
+  $isExtensionHost = $commandLine -like "*--inspect=127.0.0.1:$Port*" `
+    -or $commandLine -like "*--inspect-brk=127.0.0.1:$Port*" `
+    -or $commandLine -like "*--inspect=localhost:$Port*" `
+    -or $commandLine -like "*--inspect-brk=localhost:$Port*"
+
+  if ($isExtensionHost) {
+    Stop-Process -Id $processId -Force -ErrorAction SilentlyContinue
+    continue
+  }
+
+  [Console]::Error.WriteLine("Port $Port is already used by PID $processId, but it does not look like a VS Code extension host:`n$commandLine`nRefusing to stop it automatically.")
+  exit 1
+}
+
+& $cli `
+  --new-window `
+  "--inspect-extensions=$Port" `
+  "--extensionDevelopmentPath=$Workspace" `
+  $Workspace
+
+if ($LASTEXITCODE) {
+  exit $LASTEXITCODE
+}

--- a/.vscode/launch-extension-host.sh
+++ b/.vscode/launch-extension-host.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: launch-extension-host.sh <stable|insiders> <port> <workspace>
+EOF
+}
+
+quality="${1:-}"
+port="${2:-}"
+workspace="${3:-}"
+
+if [ -z "$quality" ] || [ -z "$port" ] || [ -z "$workspace" ]; then
+  usage
+  exit 2
+fi
+
+case "$quality" in
+  stable)
+    cli="code"
+    install_hint="Shell Command: Install 'code' command in PATH"
+    ;;
+  insiders)
+    cli="code-insiders"
+    install_hint="Shell Command: Install 'code-insiders' command in PATH"
+    ;;
+  *)
+    usage
+    exit 2
+    ;;
+esac
+
+if ! command -v "$cli" >/dev/null 2>&1; then
+  cat >&2 <<EOF
+Missing '$cli' in PATH.
+Install it from the target VS Code Command Palette:
+  $install_hint
+Then restart the terminal and try again.
+EOF
+  exit 127
+fi
+
+if command -v lsof >/dev/null 2>&1; then
+  pids="$(lsof -tiTCP:"$port" -sTCP:LISTEN || true)"
+  for pid in $pids; do
+    command_line="$(ps -p "$pid" -o command= 2>/dev/null || true)"
+    case "$command_line" in
+      *"--inspect=127.0.0.1:$port"*|*"--inspect-brk=127.0.0.1:$port"*|*"--inspect=localhost:$port"*|*"--inspect-brk=localhost:$port"*)
+        kill "$pid" 2>/dev/null || true
+        ;;
+      "")
+        ;;
+      *)
+        cat >&2 <<EOF
+Port $port is already used by PID $pid, but it does not look like a VS Code extension host:
+$command_line
+Refusing to stop it automatically.
+EOF
+        exit 1
+        ;;
+    esac
+  done
+else
+  echo "Warning: lsof is not available; skipping stale inspector cleanup for port $port." >&2
+fi
+
+"$cli" \
+  --new-window \
+  "--inspect-extensions=$port" \
+  "--extensionDevelopmentPath=$workspace" \
+  "$workspace"

--- a/.vscode/launch-extension-host.sh
+++ b/.vscode/launch-extension-host.sh
@@ -41,15 +41,38 @@ EOF
   exit 127
 fi
 
+is_port_listening() {
+  lsof -tiTCP:"$port" -sTCP:LISTEN >/dev/null 2>&1
+}
+
+wait_for_port_release() {
+  for _ in 1 2 3 4 5 6 7 8 9 10; do
+    if ! is_port_listening; then
+      return 0
+    fi
+    sleep 0.2
+  done
+
+  echo "Port $port is still in use after stopping stale extension host processes." >&2
+  return 1
+}
+
 if command -v lsof >/dev/null 2>&1; then
+  stopped_process=false
   pids="$(lsof -tiTCP:"$port" -sTCP:LISTEN || true)"
   for pid in $pids; do
     command_line="$(ps -p "$pid" -o command= 2>/dev/null || true)"
     case "$command_line" in
       *"--inspect=127.0.0.1:$port"*|*"--inspect-brk=127.0.0.1:$port"*|*"--inspect=localhost:$port"*|*"--inspect-brk=localhost:$port"*)
         kill "$pid" 2>/dev/null || true
+        stopped_process=true
         ;;
       "")
+        cat >&2 <<EOF
+Port $port is already used by PID $pid, but its command line could not be inspected.
+Refusing to stop it automatically.
+EOF
+        exit 1
         ;;
       *)
         cat >&2 <<EOF
@@ -61,6 +84,10 @@ EOF
         ;;
     esac
   done
+
+  if [ "$stopped_process" = true ]; then
+    wait_for_port_release
+  fi
 else
   echo "Warning: lsof is not available; skipping stale inspector cleanup for port $port." >&2
 fi

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -3,25 +3,33 @@
   "configurations": [
     {
       "name": "Run Extension (Insiders)",
-      "type": "extensionHost",
-      "request": "launch",
-      "args": [
-        "--extensionDevelopmentPath=${workspaceFolder}"
+      "type": "node",
+      "request": "attach",
+      "port": 9333,
+      "timeout": 30000,
+      "continueOnAttach": true,
+      "skipFiles": [
+        "<node_internals>/**"
       ],
       "outFiles": [
         "${workspaceFolder}/out/**/*.js"
       ],
-      "preLaunchTask": "npm: watch"
+      "preLaunchTask": "Launch Extension Host (Insiders)"
     },
     {
       "name": "Run Extension (Stable)",
       "type": "node",
-      "request": "launch",
-      "runtimeExecutable": "/Applications/Visual Studio Code.app/Contents/MacOS/Electron",
-      "runtimeArgs": [
-        "--extensionDevelopmentPath=${workspaceFolder}",
-        "${workspaceFolder}"
-      ]
+      "request": "attach",
+      "port": 9334,
+      "timeout": 30000,
+      "continueOnAttach": true,
+      "skipFiles": [
+        "<node_internals>/**"
+      ],
+      "outFiles": [
+        "${workspaceFolder}/out/**/*.js"
+      ],
+      "preLaunchTask": "Launch Extension Host (Stable)"
     }
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,7 +2,20 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "Run Extension (Insiders)",
+      "name": "Run Extension (Current VS Code)",
+      "type": "extensionHost",
+      "request": "launch",
+      "args": [
+        "--extensionDevelopmentPath=${workspaceFolder}",
+        "${workspaceFolder}"
+      ],
+      "outFiles": [
+        "${workspaceFolder}/out/**/*.js"
+      ],
+      "preLaunchTask": "npm: watch"
+    },
+    {
+      "name": "Run Extension (Insiders via CLI)",
       "type": "node",
       "request": "attach",
       "port": 9333,
@@ -14,10 +27,10 @@
       "outFiles": [
         "${workspaceFolder}/out/**/*.js"
       ],
-      "preLaunchTask": "Launch Extension Host (Insiders)"
+      "preLaunchTask": "Launch Extension Host (Insiders CLI)"
     },
     {
-      "name": "Run Extension (Stable)",
+      "name": "Run Extension (Stable via CLI)",
       "type": "node",
       "request": "attach",
       "port": 9334,
@@ -29,7 +42,7 @@
       "outFiles": [
         "${workspaceFolder}/out/**/*.js"
       ],
-      "preLaunchTask": "Launch Extension Host (Stable)"
+      "preLaunchTask": "Launch Extension Host (Stable CLI)"
     }
   ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -21,6 +21,19 @@
         "9333",
         "${workspaceFolder}"
       ],
+      "windows": {
+        "command": "powershell",
+        "args": [
+          "-NoProfile",
+          "-ExecutionPolicy",
+          "Bypass",
+          "-File",
+          "${workspaceFolder}/.vscode/launch-extension-host.ps1",
+          "insiders",
+          "9333",
+          "${workspaceFolder}"
+        ]
+      },
       "dependsOn": "npm: watch",
       "dependsOrder": "sequence",
       "problemMatcher": []
@@ -35,6 +48,19 @@
         "9334",
         "${workspaceFolder}"
       ],
+      "windows": {
+        "command": "powershell",
+        "args": [
+          "-NoProfile",
+          "-ExecutionPolicy",
+          "Bypass",
+          "-File",
+          "${workspaceFolder}/.vscode/launch-extension-host.ps1",
+          "stable",
+          "9334",
+          "${workspaceFolder}"
+        ]
+      },
       "dependsOn": "npm: watch",
       "dependsOrder": "sequence",
       "problemMatcher": []

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -12,17 +12,29 @@
       "group": "build"
     },
     {
-      "label": "Launch Extension Host (Insiders)",
+      "label": "Launch Extension Host (Insiders CLI)",
       "type": "shell",
-      "command": "debug_pid=$(lsof -tiTCP:9333 -sTCP:LISTEN | head -n 1); if [ -n \"$debug_pid\" ]; then debug_ppid=$(ps -p \"$debug_pid\" -o ppid= | tr -d ' '); kill \"$debug_ppid\" 2>/dev/null || kill \"$debug_pid\" 2>/dev/null || true; fi; open -n '/Applications/Visual Studio Code - Insiders.app' --args --new-window --inspect-extensions=9333 --extensionDevelopmentPath='${workspaceFolder}' '${workspaceFolder}'",
+      "command": "bash",
+      "args": [
+        "${workspaceFolder}/.vscode/launch-extension-host.sh",
+        "insiders",
+        "9333",
+        "${workspaceFolder}"
+      ],
       "dependsOn": "npm: watch",
       "dependsOrder": "sequence",
       "problemMatcher": []
     },
     {
-      "label": "Launch Extension Host (Stable)",
+      "label": "Launch Extension Host (Stable CLI)",
       "type": "shell",
-      "command": "debug_pid=$(lsof -tiTCP:9334 -sTCP:LISTEN | head -n 1); if [ -n \"$debug_pid\" ]; then debug_ppid=$(ps -p \"$debug_pid\" -o ppid= | tr -d ' '); kill \"$debug_ppid\" 2>/dev/null || kill \"$debug_pid\" 2>/dev/null || true; fi; open -n '/Applications/Visual Studio Code.app' --args --new-window --inspect-extensions=9334 --extensionDevelopmentPath='${workspaceFolder}' '${workspaceFolder}'",
+      "command": "bash",
+      "args": [
+        "${workspaceFolder}/.vscode/launch-extension-host.sh",
+        "stable",
+        "9334",
+        "${workspaceFolder}"
+      ],
       "dependsOn": "npm: watch",
       "dependsOrder": "sequence",
       "problemMatcher": []

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -10,6 +10,22 @@
         "reveal": "silent"
       },
       "group": "build"
+    },
+    {
+      "label": "Launch Extension Host (Insiders)",
+      "type": "shell",
+      "command": "debug_pid=$(lsof -tiTCP:9333 -sTCP:LISTEN | head -n 1); if [ -n \"$debug_pid\" ]; then debug_ppid=$(ps -p \"$debug_pid\" -o ppid= | tr -d ' '); kill \"$debug_ppid\" 2>/dev/null || kill \"$debug_pid\" 2>/dev/null || true; fi; open -n '/Applications/Visual Studio Code - Insiders.app' --args --new-window --inspect-extensions=9333 --extensionDevelopmentPath='${workspaceFolder}' '${workspaceFolder}'",
+      "dependsOn": "npm: watch",
+      "dependsOrder": "sequence",
+      "problemMatcher": []
+    },
+    {
+      "label": "Launch Extension Host (Stable)",
+      "type": "shell",
+      "command": "debug_pid=$(lsof -tiTCP:9334 -sTCP:LISTEN | head -n 1); if [ -n \"$debug_pid\" ]; then debug_ppid=$(ps -p \"$debug_pid\" -o ppid= | tr -d ' '); kill \"$debug_ppid\" 2>/dev/null || kill \"$debug_pid\" 2>/dev/null || true; fi; open -n '/Applications/Visual Studio Code.app' --args --new-window --inspect-extensions=9334 --extensionDevelopmentPath='${workspaceFolder}' '${workspaceFolder}'",
+      "dependsOn": "npm: watch",
+      "dependsOrder": "sequence",
+      "problemMatcher": []
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add product-specific debug flows for VS Code Stable and Insiders
- launch the requested VS Code app explicitly before attaching to the extension host inspector port
- clear stale debug listeners before relaunching to avoid attaching to an old paused extension host

## Validation
- verified the configs locally with VS Code Stable and Insiders
- VS Code reported no schema errors for `.vscode/launch.json` or `.vscode/tasks.json`

## Release notes
- Conventional commit type is `chore(debug)`, which is hidden from the release-please changelog by this repo's config.