### PR TITLE
chore(i18n): clean up follow-up localization issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
         "deepseek-copilot.visionPrompt": {
           "type": "string",
           "editPresentation": "multilineText",
-          "default": "%deepseek-copilot.config.visionPrompt.default%",
+          "default": "Describe the visual contents of this image in detail, including any text, objects, people, or context that would be relevant for understanding it. Focus on factual visual elements.",
           "description": "%deepseek-copilot.config.visionPrompt.description%"
         }
       }

--- a/package.nls.json
+++ b/package.nls.json
@@ -21,6 +21,5 @@
   "deepseek-copilot.config.modelIdOverrides.deepseek-v4-flash.description": "API model ID for DeepSeek V4 Flash",
   "deepseek-copilot.config.modelIdOverrides.deepseek-v4-pro.description": "API model ID for DeepSeek V4 Pro",
   "deepseek-copilot.config.visionModel.description": "Model ID for vision proxy (describes images for text-only DeepSeek models). Leave empty for auto-detection. Use 'DeepSeek: Set Vision Proxy Model' command to pick one from a list.",
-  "deepseek-copilot.config.visionPrompt.description": "Prompt sent to the vision proxy model when describing image attachments before forwarding them to DeepSeek.",
-  "deepseek-copilot.config.visionPrompt.default": "Describe the visual contents of this image in detail, including any text, objects, people, or context that would be relevant for understanding it. Focus on factual visual elements."
+  "deepseek-copilot.config.visionPrompt.description": "Prompt sent to the vision proxy model when describing image attachments before forwarding them to DeepSeek."
 }

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -21,6 +21,5 @@
   "deepseek-copilot.config.modelIdOverrides.deepseek-v4-flash.description": "DeepSeek V4 Flash 的 API 模型 ID。",
   "deepseek-copilot.config.modelIdOverrides.deepseek-v4-pro.description": "DeepSeek V4 Pro 的 API 模型 ID。",
   "deepseek-copilot.config.visionModel.description": "用于描述图片的视觉代理模型 ID，留空则自动检测，也可通过「DeepSeek: 设置视觉代理模型」命令从列表中选择。",
-  "deepseek-copilot.config.visionPrompt.description": "在将图片附件转发给 DeepSeek 之前，发送给视觉代理模型的提示词。",
-  "deepseek-copilot.config.visionPrompt.default": "Describe the visual contents of this image in detail, including any text, objects, people, or context that would be relevant for understanding it. Focus on factual visual elements."
+  "deepseek-copilot.config.visionPrompt.description": "在将图片附件转发给 DeepSeek 之前，发送给视觉代理模型的提示词。"
 }

--- a/resources/walkthrough/set-api-key.nls.zh-cn.md
+++ b/resources/walkthrough/set-api-key.nls.zh-cn.md
@@ -3,6 +3,6 @@ DeepSeek V4 for Copilot Chat 使用你自己的 DeepSeek API Key，让 Flash 和
 只需粘贴一次，之后可通过命令面板更新或移除。
 
 - `Cmd/Ctrl + Shift + P`：打开命令面板
-- `DeepSeek: Set API Key`：设置或更新 API Key
-- `DeepSeek: Clear API Key`：移除 API Key
-- `DeepSeek: Get API Key`：创建 DeepSeek API Key
+- `DeepSeek: 设置 API Key`：设置或更新 API Key
+- `DeepSeek: 清除 API Key`：移除 API Key
+- `DeepSeek: 获取 API Key`：创建 DeepSeek API Key

--- a/resources/walkthrough/show-models.nls.zh-cn.md
+++ b/resources/walkthrough/show-models.nls.zh-cn.md
@@ -1,3 +1,3 @@
-扩展激活后，DeepSeek 模型应立即出现在 Copilot 模型选择器中。如果尚未配置 API Key，模型会显示警告图标，直到你运行 DeepSeek: Set API Key 为止。
+扩展激活后，DeepSeek 模型应立即出现在 Copilot 模型选择器中。如果尚未配置 API Key，模型会显示警告图标，直到你运行 `DeepSeek: 设置 API Key` 为止。
 
 如果没有立即看到，可能只是模型列表较长。在选取器中向下滚动，查找 DeepSeek V4 Flash 和 Pro。

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,5 +1,4 @@
 import type { CancellationToken } from 'vscode';
-import { t } from './i18n';
 import { logger } from './logger';
 import type {
 	DeepSeekRequest,
@@ -59,11 +58,11 @@ export class DeepSeekClient {
 				} catch {
 					errorMessage = errorText;
 				}
-				throw new Error(t('client.apiError', response.status, errorMessage));
+				throw new Error(`DeepSeek API error (${response.status}): ${errorMessage}`);
 			}
 
 			if (!response.body) {
-				throw new Error(t('client.noResponseBody'));
+				throw new Error('No response body received');
 			}
 
 			const reader = response.body.getReader();

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,4 +1,5 @@
 import type { CancellationToken } from 'vscode';
+import { t } from './i18n';
 import { logger } from './logger';
 import type {
 	DeepSeekRequest,
@@ -58,11 +59,11 @@ export class DeepSeekClient {
 				} catch {
 					errorMessage = errorText;
 				}
-				throw new Error(`DeepSeek API error (${response.status}): ${errorMessage}`);
+				throw new Error(t('client.apiError', response.status, errorMessage));
 			}
 
 			if (!response.body) {
-				throw new Error('No response body received');
+				throw new Error(t('client.noResponseBody'));
 			}
 
 			const reader = response.body.getReader();

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -43,13 +43,17 @@ const zh: Translations = {
 
 	// Vision
 	'vision.vendorLabel': '提供商：{0}',
-	'vision.noModel': '当前环境中无可用的语言模型。',
+	'vision.noModel': '当前环境中没有可用的非 DeepSeek 视觉代理模型。',
 	'vision.pickPlaceholder': '选择用于描述图片的模型 (默认 {0})',
 	'vision.current': '当前',
 	'vision.proxyUsing': '视觉代理：{0}',
 	'vision.notFound': '未找到视觉模型 "{0}"',
 	'vision.unavailable': '无可用视觉模型，图片已忽略。',
 	'vision.proxyError': '视觉代理异常：',
+
+	// Client
+	'client.apiError': 'DeepSeek API 错误（{0}）：{1}',
+	'client.noResponseBody': '未收到响应正文',
 
 	// Extension
 	'extension.activateFailed': 'DeepSeek 激活失败，请运行 "DeepSeek: 显示日志" 查看详情。',
@@ -86,13 +90,17 @@ const en: Translations = {
 	// NOTE: vision.unableToDescribe has been moved to consts.ts as
 	// IMAGE_DESCRIPTION_UNAVAILABLE — it is prompt content, not UI text.
 	'vision.vendorLabel': 'vendor: {0}',
-	'vision.noModel': 'No language models available in the current environment',
+	'vision.noModel': 'No non-DeepSeek vision proxy models are available in the current environment',
 	'vision.pickPlaceholder': 'Select a model for image description (default: {0})',
 	'vision.current': 'Current',
 	'vision.proxyUsing': 'Vision proxy: {0}',
 	'vision.notFound': 'Vision model "{0}" not found',
 	'vision.unavailable': 'No vision models available, image(s) ignored',
 	'vision.proxyError': 'Vision proxy error:',
+
+	// Client
+	'client.apiError': 'DeepSeek API error ({0}): {1}',
+	'client.noResponseBody': 'No response body received',
 
 	// Extension
 	'extension.activateFailed': 'DeepSeek failed to activate. Run "DeepSeek: Show Logs" for details.',

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -51,10 +51,6 @@ const zh: Translations = {
 	'vision.unavailable': '无可用视觉模型，图片已忽略。',
 	'vision.proxyError': '视觉代理异常：',
 
-	// Client
-	'client.apiError': 'DeepSeek API 错误（{0}）：{1}',
-	'client.noResponseBody': '未收到响应正文',
-
 	// Extension
 	'extension.activateFailed': 'DeepSeek 激活失败，请运行 "DeepSeek: 显示日志" 查看详情。',
 	'extension.deactivateFailed': 'DeepSeek 停用异常',
@@ -97,10 +93,6 @@ const en: Translations = {
 	'vision.notFound': 'Vision model "{0}" not found',
 	'vision.unavailable': 'No vision models available, image(s) ignored',
 	'vision.proxyError': 'Vision proxy error:',
-
-	// Client
-	'client.apiError': 'DeepSeek API error ({0}): {1}',
-	'client.noResponseBody': 'No response body received',
 
 	// Extension
 	'extension.activateFailed': 'DeepSeek failed to activate. Run "DeepSeek: Show Logs" for details.',


### PR DESCRIPTION
## Summary

- keep the vision prompt default out of package NLS so prompt content is not treated as translatable UI text
- align zh-cn walkthrough command labels with the localized command titles
- clarify the vision proxy no-candidate message when only DeepSeek models are available
- remove i18n dependency from client.ts so the transport layer stays free of VS Code runtime imports; API errors remain in plain English for now

## Verification

- `jq empty package.json package.nls.json package.nls.zh-cn.json`
- package NLS placeholder/key coverage check for English and zh-cn
- `npm run format:check`
- `npm run lint`
- `npm run compile`