### PR TITLE
Add opt-in cache trace diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Both support optional thinking mode, tool calling, and 1M token context.
 | `deepseek-copilot.baseUrl` | `https://api.deepseek.com` | API endpoint — change for self-hosted / proxied deployments |
 | `deepseek-copilot.maxTokens` | `0` | Max output tokens (`0` = no limit). Useful for cost control |
 | `deepseek-copilot.modelIdOverrides` | prefilled official ID map | API model IDs to send for DeepSeek V4 Flash / Pro. Change only for compatible third-party APIs with different model names |
+| `deepseek-copilot.debug` | `false` | Enable privacy-preserving diagnostic debug logs for troubleshooting. Does not log prompt text |
 | `deepseek-copilot.visionModel` | *(auto)* | Which Copilot model to proxy images through |
 | `deepseek-copilot.visionPrompt` | *(built-in)* | Prompt used to describe image attachments |
 

--- a/package.json
+++ b/package.json
@@ -120,6 +120,11 @@
           "minimum": 0,
           "description": "%deepseek-copilot.config.maxTokens.description%"
         },
+        "deepseek-copilot.debug": {
+          "type": "boolean",
+          "default": false,
+          "description": "%deepseek-copilot.config.debug.description%"
+        },
         "deepseek-copilot.modelIdOverrides": {
           "type": "object",
           "default": {

--- a/package.nls.json
+++ b/package.nls.json
@@ -17,6 +17,7 @@
   "deepseek-copilot.config.title": "DeepSeek Copilot",
   "deepseek-copilot.config.baseUrl.description": "DeepSeek API base URL. Defaults to official DeepSeek API endpoint.",
   "deepseek-copilot.config.maxTokens.description": "Maximum number of output tokens per request. Set to 0 to use the API default (no limit). Useful for controlling costs.",
+  "deepseek-copilot.config.debug.description": "Enable diagnostic debug logging for troubleshooting. Logs privacy-preserving metadata such as request hashes, prefix overlap, tool schema changes, and missing reasoning_content. Does not log prompt text.",
   "deepseek-copilot.config.modelIdOverrides.description": "Override the API model ID sent for each DeepSeek model. Defaults are prefilled with official DeepSeek IDs; change them only when using a compatible third-party API that uses different model names.",
   "deepseek-copilot.config.modelIdOverrides.deepseek-v4-flash.description": "API model ID for DeepSeek V4 Flash",
   "deepseek-copilot.config.modelIdOverrides.deepseek-v4-pro.description": "API model ID for DeepSeek V4 Pro",

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -17,6 +17,7 @@
   "deepseek-copilot.config.title": "DeepSeek 助手",
   "deepseek-copilot.config.baseUrl.description": "DeepSeek API 基础 URL，默认为官方 DeepSeek API 端点。",
   "deepseek-copilot.config.maxTokens.description": "每次请求的最大输出 Token 数，设为 0 则不限制，可用于控制成本。",
+  "deepseek-copilot.config.debug.description": "启用用于排查问题的诊断调试日志。日志只包含请求哈希、前缀重合度、工具定义变化、缺失 reasoning_content 等隐私保护后的元数据，不记录提示词原文。",
   "deepseek-copilot.config.modelIdOverrides.description": "覆盖各 DeepSeek 模型实际使用的 API 模型 ID，默认使用官方 DeepSeek ID，仅在对接不同模型名称的第三方 API 时需要修改。",
   "deepseek-copilot.config.modelIdOverrides.deepseek-v4-flash.description": "DeepSeek V4 Flash 的 API 模型 ID。",
   "deepseek-copilot.config.modelIdOverrides.deepseek-v4-pro.description": "DeepSeek V4 Pro 的 API 模型 ID。",

--- a/src/config.ts
+++ b/src/config.ts
@@ -33,3 +33,11 @@ export function getMaxTokens(): number | undefined {
 	const value = config.get<number>('maxTokens', 0);
 	return value > 0 ? value : undefined;
 }
+
+/**
+ * Whether to log privacy-preserving diagnostic debug information.
+ */
+export function getDebugLoggingEnabled(): boolean {
+	const config = vscode.workspace.getConfiguration(CONFIG_SECTION);
+	return config.get<boolean>('debug', false);
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,5 @@
 import vscode from 'vscode';
+import { getDebugLoggingEnabled } from './config';
 import { WALKTHROUGH_ID, WELCOME_SHOWN_KEY } from './consts';
 import { t } from './i18n';
 import { logger } from './logger';
@@ -7,7 +8,10 @@ import { DeepSeekChatProvider } from './provider';
 let activeProvider: DeepSeekChatProvider | undefined;
 
 export function activate(context: vscode.ExtensionContext) {
-	logger.info('Activating extension');
+	logger.info(
+		`Activating extension version=${context.extension.packageJSON.version}` +
+			` debug=${getDebugLoggingEnabled()}`,
+	);
 
 	context.subscriptions.push(
 		vscode.commands.registerCommand('deepseek-copilot.showLogs', () => logger.show()),
@@ -57,7 +61,7 @@ export function activate(context: vscode.ExtensionContext) {
 			logger.warn(t('extension.welcomeFailed'), error);
 		});
 
-		logger.info('Extension activated');
+		logger.info(`Extension activated version=${context.extension.packageJSON.version}`);
 	} catch (error) {
 		activeProvider = undefined;
 		logger.error('Failed to activate DeepSeek extension', error);

--- a/src/provider/diagnostics.ts
+++ b/src/provider/diagnostics.ts
@@ -72,7 +72,7 @@ export interface CacheTraceToolSummary {
 export interface CacheTraceSnapshot {
 	fingerprint: string;
 	conversationKey: string;
-	serializedInput: string;
+	redactedComparisonInput: string;
 	toolsHash: string;
 	toolNames: string[];
 	toolSummaries: CacheTraceToolSummary[];
@@ -81,8 +81,8 @@ export interface CacheTraceSnapshot {
 }
 
 export interface CacheTraceComparison {
-	commonPrefixChars: number;
-	commonPrefixPercent: number;
+	commonPrefixSummaryChars: number;
+	commonPrefixSummaryPercent: number;
 	previousMessageCount: number;
 	currentMessageCount: number;
 	firstChangedMessageIndex: number | undefined;
@@ -136,10 +136,6 @@ interface VisionResolutionStats {
 	describedImageMessages: number;
 	failedImageMessages: number;
 	droppedImageParts: number;
-	descriptionCacheEnabled: boolean;
-	descriptionCacheHits: number;
-	descriptionCacheMisses: number;
-	descriptionCacheEntries: number;
 	visionModelId?: string;
 }
 
@@ -160,6 +156,7 @@ class DefaultCacheDiagnosticsRecorder implements CacheDiagnosticsRecorder {
 
 	beginRequest(options: BeginCacheDiagnosticsOptions): CacheDiagnosticsRun {
 		if (!this.isEnabled()) {
+			this.clearCacheTraces();
 			return new NoopCacheDiagnosticsRun();
 		}
 
@@ -186,8 +183,14 @@ class DefaultCacheDiagnosticsRecorder implements CacheDiagnosticsRecorder {
 				` thinking=${options.isThinkingModel}` +
 				` thinkingEffort=${options.thinkingEffort}` +
 				` maxTokens=${options.maxTokens ?? 'api-default'}` +
-				` reasoningCache(size=${options.reasoningCacheSize},max=${MAX_CACHE_SIZE})`,
+				` reasoningCache(size=${options.reasoningCacheSize},max=${MAX_CACHE_SIZE})` +
+				` inputMessages=${options.inputMessages.length}` +
+				` deepseekMessages=${options.request.messages.length}`,
 		);
+		const vscodeMessageTrace = formatVscodeMessageTrace(options.inputMessages);
+		if (vscodeMessageTrace) {
+			logger.info(`[cache-trace #${requestId}] vscodeMsgs ${vscodeMessageTrace}`);
+		}
 		for (const detailLine of formatCacheTraceDetailLines(cacheTrace)) {
 			logger.info(`[cache-trace #${requestId}] ${detailLine}`);
 		}
@@ -235,8 +238,13 @@ class DefaultCacheDiagnosticsRecorder implements CacheDiagnosticsRecorder {
 			requestId,
 			cacheTrace,
 			cacheTraceComparison ?? conversationChangeComparison,
-			cacheTraceComparison ? 'prefixVsPrevious' : 'fallbackPrefixVsPrevious',
+			cacheTraceComparison ? 'summaryPrefixVsPrevious' : 'fallbackSummaryPrefixVsPrevious',
 		);
+	}
+
+	private clearCacheTraces(): void {
+		this.lastCacheTrace = undefined;
+		this.previousCacheTraces.clear();
 	}
 
 	rememberCacheTrace(snapshot: CacheTraceSnapshot): void {
@@ -280,8 +288,8 @@ class ActiveCacheDiagnosticsRun implements CacheDiagnosticsRun {
 			const hitRate = getCacheHitRate(usage);
 			logger.info(
 				`[cache-trace #${this.requestId}] result cacheRate=${hitRate}%` +
-					` ${this.prefixLabel}=${this.resultComparison.commonPrefixChars}` +
-					` chars (${this.resultComparison.commonPrefixPercent.toFixed(1)}%)`,
+					` ${this.prefixLabel}=${this.resultComparison.commonPrefixSummaryChars}` +
+					` chars (${this.resultComparison.commonPrefixSummaryPercent.toFixed(1)}%)`,
 			);
 		}
 	}
@@ -323,10 +331,6 @@ function summarizeVisionResolution(
 		describedImageMessages: 0,
 		failedImageMessages: 0,
 		droppedImageParts: 0,
-		descriptionCacheEnabled: false,
-		descriptionCacheHits: 0,
-		descriptionCacheMisses: 0,
-		descriptionCacheEntries: 0,
 		visionModelId,
 	};
 
@@ -353,7 +357,6 @@ function summarizeVisionResolution(
 
 			if (newDescriptions > 0) {
 				stats.describedImageMessages += 1;
-				stats.descriptionCacheMisses += 1;
 			}
 			if (newFailures > 0) {
 				stats.failedImageMessages += 1;
@@ -402,7 +405,6 @@ function formatVisionTrace(
 		` newDescriptionMessages=${stats.describedImageMessages}` +
 		` failedDescriptionMessages=${stats.failedImageMessages}` +
 		` droppedImageParts=${stats.droppedImageParts}` +
-		` descriptionCache(enabled=${stats.descriptionCacheEnabled},hits=${stats.descriptionCacheHits},misses=${stats.descriptionCacheMisses},entries=${stats.descriptionCacheEntries})` +
 		` visionModel=${visionModel}` +
 		` historyDescriptionMessages=${historyDescriptionMessages}` +
 		note
@@ -426,31 +428,95 @@ function formatVisionModel(stats: VisionResolutionStats): string {
 	return 'unknown';
 }
 
+function formatVscodeMessageTrace(
+	messages: readonly vscode.LanguageModelChatRequestMessage[],
+): string | undefined {
+	if (messages.length === 0) {
+		return undefined;
+	}
+
+	return messages
+		.map((msg, index) => {
+			const role =
+				msg.role === vscode.LanguageModelChatMessageRole.User
+					? 'user'
+					: msg.role === vscode.LanguageModelChatMessageRole.Assistant
+						? 'assistant'
+						: 'unknown';
+			let textChars = 0;
+			let imageParts = 0;
+			let toolCallParts = 0;
+			let toolResultParts = 0;
+
+			for (const part of msg.content) {
+				if (part instanceof vscode.LanguageModelTextPart) {
+					textChars += part.value.length;
+				} else if (
+					part instanceof vscode.LanguageModelDataPart &&
+					part.mimeType.startsWith('image/')
+				) {
+					imageParts += 1;
+				} else if (part instanceof vscode.LanguageModelToolCallPart) {
+					toolCallParts += 1;
+				} else if (part instanceof vscode.LanguageModelToolResultPart) {
+					toolResultParts += 1;
+				}
+			}
+
+			const parts: string[] = [];
+			if (imageParts) {
+				parts.push(`image=${imageParts}`);
+			}
+			if (toolCallParts) {
+				parts.push(`toolCalls=${toolCallParts}`);
+			}
+			if (toolResultParts) {
+				parts.push(`toolResults=${toolResultParts}`);
+			}
+
+			const suffix = parts.length > 0 ? ` (${parts.join(',')})` : '';
+
+			return `${role}#${index}:chars=${textChars}${suffix}`;
+		})
+		.join(' | ');
+}
+
 export function createCacheTraceSnapshot(request: DeepSeekRequest): CacheTraceSnapshot {
-	const cacheInput = {
-		model: request.model,
-		tools: request.tools ?? null,
-		tool_choice: request.tool_choice ?? null,
-		thinking: request.thinking ?? null,
-		reasoning_effort: request.reasoning_effort ?? null,
-		messages: request.messages,
-	};
-	const serializedInput = stableStringify(cacheInput);
 	const toolsSerialized = stableStringify(request.tools ?? []);
 	const messageSummaries = summarizeMessages(request.messages);
 	const toolSummaries = summarizeTools(request.tools ?? []);
 	const firstMessage = messageSummaries[0];
+	const redactedComparisonInput = createRedactedComparisonInput(
+		request,
+		messageSummaries,
+		toolSummaries,
+	);
 
 	return {
-		fingerprint: hashString(serializedInput),
+		fingerprint: hashString(redactedComparisonInput),
 		conversationKey: hashString(`${request.model}:${firstMessage?.hash ?? 'empty'}`),
-		serializedInput,
+		redactedComparisonInput,
 		toolsHash: hashString(toolsSerialized),
 		toolNames: request.tools?.map((tool) => tool.function.name) ?? [],
 		toolSummaries,
 		messageSummaries,
 		stats: summarizeStats(request.messages, request.tools?.length ?? 0),
 	};
+}
+
+function createRedactedComparisonInput(
+	request: DeepSeekRequest,
+	messageSummaries: CacheTraceMessageSummary[],
+	toolSummaries: CacheTraceToolSummary[],
+): string {
+	return stableStringify({
+		model: request.model,
+		tool_choice: request.tool_choice ?? null,
+		thinking: request.thinking ?? null,
+		reasoning_effort: request.reasoning_effort ?? null,
+		tools: toolSummaries,
+		messages: messageSummaries,
+	});
 }
 
 export function compareCacheTraceSnapshots(
@@ -461,9 +527,9 @@ export function compareCacheTraceSnapshots(
 		return undefined;
 	}
 
-	const commonPrefixChars = countCommonPrefixChars(
-		previous.serializedInput,
-		current.serializedInput,
+	const commonPrefixSummaryChars = countCommonPrefixChars(
+		previous.redactedComparisonInput,
+		current.redactedComparisonInput,
 	);
 	const firstChangedMessageIndex = findFirstChangedMessageIndex(
 		previous.messageSummaries,
@@ -475,10 +541,10 @@ export function compareCacheTraceSnapshots(
 	);
 
 	return {
-		commonPrefixChars,
-		commonPrefixPercent:
-			current.serializedInput.length > 0
-				? (commonPrefixChars / current.serializedInput.length) * 100
+		commonPrefixSummaryChars,
+		commonPrefixSummaryPercent:
+			current.redactedComparisonInput.length > 0
+				? (commonPrefixSummaryChars / current.redactedComparisonInput.length) * 100
 				: 100,
 		previousMessageCount: previous.messageSummaries.length,
 		currentMessageCount: current.messageSummaries.length,
@@ -553,8 +619,8 @@ export function formatCacheTraceComparison(comparison: CacheTraceComparison): st
 		: '';
 
 	return (
-		`prefixVsPrevious chars=${comparison.commonPrefixChars}` +
-		` percent=${comparison.commonPrefixPercent.toFixed(1)}%` +
+		`summaryPrefixVsPrevious chars=${comparison.commonPrefixSummaryChars}` +
+		` percent=${comparison.commonPrefixSummaryPercent.toFixed(1)}%` +
 		` toolsChanged=${comparison.toolsChanged}` +
 		` toolsHash=${comparison.previousToolsHash}->${comparison.currentToolsHash}` +
 		changedTool +
@@ -579,8 +645,8 @@ export function formatCacheTraceConversationChangeComparison(
 
 	return (
 		`conversationChanged=true prev=${previousConversationKey} curr=${currentConversationKey}` +
-		` fallbackPrefixVsPrevious chars=${comparison.commonPrefixChars}` +
-		` percent=${comparison.commonPrefixPercent.toFixed(1)}%` +
+		` fallbackSummaryPrefixVsPrevious chars=${comparison.commonPrefixSummaryChars}` +
+		` percent=${comparison.commonPrefixSummaryPercent.toFixed(1)}%` +
 		` toolsChanged=${comparison.toolsChanged}` +
 		` toolsHash=${comparison.previousToolsHash}->${comparison.currentToolsHash}` +
 		changedTool +
@@ -653,7 +719,7 @@ export function getCacheTraceComparisonWarnings(comparison: CacheTraceComparison
 			comparison.previousMessageCount - comparison.firstChangedMessageIndex - 1;
 		if (previousMessagesAfterChange > 2) {
 			warnings.push(
-				`retained history changed before the append boundary at message #${comparison.firstChangedMessageIndex}; ${previousMessagesAfterChange} previous message(s) after it cannot share an identical serialized prefix.`,
+				`retained history changed before the append boundary at message #${comparison.firstChangedMessageIndex}; ${previousMessagesAfterChange} previous message(s) after it cannot share an identical request prefix.`,
 			);
 		}
 		if (

--- a/src/provider/diagnostics.ts
+++ b/src/provider/diagnostics.ts
@@ -1,0 +1,1038 @@
+import { createHash } from 'crypto';
+import vscode from 'vscode';
+import { getDebugLoggingEnabled } from '../config';
+import { MAX_CACHE_SIZE } from '../consts';
+import { logger } from '../logger';
+import type { DeepSeekMessage, DeepSeekRequest, DeepSeekTool, DeepSeekUsage } from '../types';
+
+const LARGE_MESSAGE_CHARS = 10_000;
+const HASH_WINDOW_CHARS = 2_048;
+
+export interface CacheTraceStats {
+	messageCount: number;
+	userMessages: number;
+	assistantMessages: number;
+	toolMessages: number;
+	systemMessages: number;
+	toolCount: number;
+	totalContentChars: number;
+	toolCallArgumentChars: number;
+	reasoningChars: number;
+	largeMessages: number;
+	assistantToolCallMessages: number;
+	nonEmptyToolReasoningMessages: number;
+	emptyToolReasoningMessages: number;
+	missingToolReasoningMessages: number;
+	assistantAfterToolResultMessages: number;
+	nonEmptyPostToolReasoningMessages: number;
+	emptyPostToolReasoningMessages: number;
+	missingPostToolReasoningMessages: number;
+	imageDescriptionMessages: number;
+	imageDescriptionParts: number;
+	unableImageMessages: number;
+	urlMessages: number;
+	urlCount: number;
+	codeFenceMessages: number;
+	codeFenceCount: number;
+	likelyPathMessages: number;
+	likelyPathCount: number;
+}
+
+export interface CacheTraceMessageSummary {
+	index: number;
+	role: DeepSeekMessage['role'];
+	hash: string;
+	contentHash: string;
+	contentHeadHash: string;
+	contentTailHash: string;
+	contentChars: number;
+	contentLines: number;
+	imageDescriptionCount: number;
+	unableImageCount: number;
+	urlCount: number;
+	codeFenceCount: number;
+	likelyPathCount: number;
+	toolCalls: number;
+	toolCallArgumentChars: number;
+	reasoningChars: number;
+	emptyReasoning: boolean;
+	missingToolReasoning: boolean;
+	followsToolResult: boolean;
+	missingPostToolReasoning: boolean;
+}
+
+export interface CacheTraceToolSummary {
+	index: number;
+	name: string;
+	hash: string;
+	descriptionHash: string;
+	parametersHash: string;
+}
+
+export interface CacheTraceSnapshot {
+	fingerprint: string;
+	conversationKey: string;
+	serializedInput: string;
+	toolsHash: string;
+	toolNames: string[];
+	toolSummaries: CacheTraceToolSummary[];
+	messageSummaries: CacheTraceMessageSummary[];
+	stats: CacheTraceStats;
+}
+
+export interface CacheTraceComparison {
+	commonPrefixChars: number;
+	commonPrefixPercent: number;
+	previousMessageCount: number;
+	currentMessageCount: number;
+	firstChangedMessageIndex: number | undefined;
+	previousMessage: CacheTraceMessageSummary | undefined;
+	currentMessage: CacheTraceMessageSummary | undefined;
+	toolsChanged: boolean;
+	previousToolsHash: string;
+	currentToolsHash: string;
+	firstChangedToolIndex: number | undefined;
+	previousTool: CacheTraceToolSummary | undefined;
+	currentTool: CacheTraceToolSummary | undefined;
+}
+
+export interface BeginCacheDiagnosticsOptions {
+	request: DeepSeekRequest;
+	vscodeModelId: string;
+	isThinkingModel: boolean;
+	thinkingEffort: string;
+	maxTokens: number | undefined;
+	reasoningCacheSize: number;
+	inputMessages: readonly vscode.LanguageModelChatRequestMessage[];
+	resolvedMessages: readonly vscode.LanguageModelChatRequestMessage[];
+	visionModelId?: string;
+}
+
+export interface CacheDiagnosticsDoneInfo {
+	reasoningCacheSize: number;
+	evictedReasoningEntries: number;
+	emittedToolCalls: number;
+	trailingToolResults: number;
+}
+
+export interface CacheDiagnosticsRun {
+	onDone(info: CacheDiagnosticsDoneInfo): void;
+	onUsage(usage: DeepSeekUsage, charsPerToken: number): void;
+}
+
+export interface CacheDiagnosticsRecorder {
+	isEnabled(): boolean;
+	logReasoningCacheCleared(removed: number): void;
+	beginRequest(options: BeginCacheDiagnosticsOptions): CacheDiagnosticsRun;
+}
+
+export function createCacheDiagnosticsRecorder(): CacheDiagnosticsRecorder {
+	return new DefaultCacheDiagnosticsRecorder();
+}
+
+interface VisionResolutionStats {
+	inputImageParts: number;
+	inputImageMessages: number;
+	describedImageMessages: number;
+	failedImageMessages: number;
+	droppedImageParts: number;
+	descriptionCacheEnabled: boolean;
+	descriptionCacheHits: number;
+	descriptionCacheMisses: number;
+	descriptionCacheEntries: number;
+	visionModelId?: string;
+}
+
+class DefaultCacheDiagnosticsRecorder implements CacheDiagnosticsRecorder {
+	private readonly previousCacheTraces = new Map<string, CacheTraceSnapshot>();
+	private lastCacheTrace: CacheTraceSnapshot | undefined;
+	private requestId = 0;
+
+	isEnabled(): boolean {
+		return getDebugLoggingEnabled();
+	}
+
+	logReasoningCacheCleared(removed: number): void {
+		if (removed > 0 && this.isEnabled()) {
+			logger.info(`reasoning-cache cleared entries=${removed} reason=conversation-start`);
+		}
+	}
+
+	beginRequest(options: BeginCacheDiagnosticsOptions): CacheDiagnosticsRun {
+		if (!this.isEnabled()) {
+			return new NoopCacheDiagnosticsRun();
+		}
+
+		const requestId = (this.requestId += 1);
+		const cacheTrace = createCacheTraceSnapshot(options.request);
+		const previousCacheTrace = this.previousCacheTraces.get(cacheTrace.conversationKey);
+		const previousImmediateCacheTrace = this.lastCacheTrace;
+		const cacheTraceComparison = compareCacheTraceSnapshots(previousCacheTrace, cacheTrace);
+		const conversationChangeComparison =
+			previousImmediateCacheTrace &&
+			previousImmediateCacheTrace.conversationKey !== cacheTrace.conversationKey
+				? compareCacheTraceSnapshots(previousImmediateCacheTrace, cacheTrace)
+				: undefined;
+		const visionResolution = summarizeVisionResolution(
+			options.inputMessages,
+			options.resolvedMessages,
+			options.visionModelId,
+		);
+
+		logger.info(`[cache-trace #${requestId}] ${formatCacheTraceSnapshot(cacheTrace)}`);
+		logger.info(
+			`[cache-trace #${requestId}] request vscodeModel=${options.vscodeModelId}` +
+				` apiModel=${options.request.model}` +
+				` thinking=${options.isThinkingModel}` +
+				` thinkingEffort=${options.thinkingEffort}` +
+				` maxTokens=${options.maxTokens ?? 'api-default'}` +
+				` reasoningCache(size=${options.reasoningCacheSize},max=${MAX_CACHE_SIZE})`,
+		);
+		for (const detailLine of formatCacheTraceDetailLines(cacheTrace)) {
+			logger.info(`[cache-trace #${requestId}] ${detailLine}`);
+		}
+		const visionTrace = formatVisionTrace(
+			visionResolution,
+			cacheTrace.stats.imageDescriptionMessages,
+		);
+		if (visionTrace) {
+			logger.info(`[cache-trace #${requestId}] ${visionTrace}`);
+		}
+		if (cacheTraceComparison) {
+			logger.info(
+				`[cache-trace #${requestId}] ${formatCacheTraceComparison(cacheTraceComparison)}`,
+			);
+			for (const detailLine of formatCacheTraceComparisonDetailLines(cacheTraceComparison)) {
+				logger.info(`[cache-trace #${requestId}] ${detailLine}`);
+			}
+			for (const warning of getCacheTraceComparisonWarnings(cacheTraceComparison)) {
+				logger.warn(`[cache-trace #${requestId}] ${warning}`);
+			}
+		}
+		if (conversationChangeComparison && previousImmediateCacheTrace) {
+			logger.info(
+				`[cache-trace #${requestId}] ${formatCacheTraceConversationChangeComparison(
+					previousImmediateCacheTrace.conversationKey,
+					cacheTrace.conversationKey,
+					conversationChangeComparison,
+				)}`,
+			);
+			for (const detailLine of formatCacheTraceComparisonDetailLines(
+				conversationChangeComparison,
+			)) {
+				logger.info(`[cache-trace #${requestId}] conversationChanged ${detailLine}`);
+			}
+			for (const warning of getCacheTraceComparisonWarnings(conversationChangeComparison)) {
+				logger.warn(`[cache-trace #${requestId}] conversationChanged fallback diff: ${warning}`);
+			}
+		}
+		for (const warning of getCacheTraceWarnings(cacheTrace)) {
+			logger.warn(`[cache-trace #${requestId}] ${warning}`);
+		}
+
+		return new ActiveCacheDiagnosticsRun(
+			this,
+			requestId,
+			cacheTrace,
+			cacheTraceComparison ?? conversationChangeComparison,
+			cacheTraceComparison ? 'prefixVsPrevious' : 'fallbackPrefixVsPrevious',
+		);
+	}
+
+	rememberCacheTrace(snapshot: CacheTraceSnapshot): void {
+		this.lastCacheTrace = snapshot;
+		this.previousCacheTraces.delete(snapshot.conversationKey);
+		this.previousCacheTraces.set(snapshot.conversationKey, snapshot);
+
+		while (this.previousCacheTraces.size > 50) {
+			const oldestKey = this.previousCacheTraces.keys().next().value;
+			if (!oldestKey) {
+				break;
+			}
+			this.previousCacheTraces.delete(oldestKey);
+		}
+	}
+}
+
+class ActiveCacheDiagnosticsRun implements CacheDiagnosticsRun {
+	constructor(
+		private readonly recorder: DefaultCacheDiagnosticsRecorder,
+		private readonly requestId: number,
+		private readonly snapshot: CacheTraceSnapshot,
+		private readonly resultComparison: CacheTraceComparison | undefined,
+		private readonly prefixLabel: string,
+	) {}
+
+	onDone(info: CacheDiagnosticsDoneInfo): void {
+		logger.info(
+			`[cache-trace #${this.requestId}] reasoningCache afterDone size=${info.reasoningCacheSize}` +
+				` max=${MAX_CACHE_SIZE}` +
+				` evicted=${info.evictedReasoningEntries}` +
+				` emittedToolCalls=${info.emittedToolCalls}` +
+				` trailingToolResults=${info.trailingToolResults}`,
+		);
+		this.recorder.rememberCacheTrace(this.snapshot);
+	}
+
+	onUsage(usage: DeepSeekUsage, charsPerToken: number): void {
+		logUsage(usage, charsPerToken, this.requestId);
+		if (this.resultComparison) {
+			const hitRate = getCacheHitRate(usage);
+			logger.info(
+				`[cache-trace #${this.requestId}] result cacheRate=${hitRate}%` +
+					` ${this.prefixLabel}=${this.resultComparison.commonPrefixChars}` +
+					` chars (${this.resultComparison.commonPrefixPercent.toFixed(1)}%)`,
+			);
+		}
+	}
+}
+
+class NoopCacheDiagnosticsRun implements CacheDiagnosticsRun {
+	onDone(_info: CacheDiagnosticsDoneInfo): void {}
+
+	onUsage(usage: DeepSeekUsage, charsPerToken: number): void {
+		logUsage(usage, charsPerToken);
+	}
+}
+
+function logUsage(usage: DeepSeekUsage, charsPerToken: number, requestId?: number): void {
+	const cacheHit = usage.prompt_cache_hit_tokens ?? 0;
+	const cacheMiss = usage.prompt_cache_miss_tokens ?? 0;
+	logger.info(
+		`tokens${requestId ? ` #${requestId}` : ''}: prompt=${usage.prompt_tokens} completion=${usage.completion_tokens}` +
+			` | cache: hit=${cacheHit} miss=${cacheMiss} rate=${getCacheHitRate(usage)}%` +
+			` | chars/tok=${charsPerToken.toFixed(2)}`,
+	);
+}
+
+function getCacheHitRate(usage: DeepSeekUsage): string {
+	const cacheHit = usage.prompt_cache_hit_tokens ?? 0;
+	const cacheMiss = usage.prompt_cache_miss_tokens ?? 0;
+	const cacheTotal = cacheHit + cacheMiss;
+	return cacheTotal > 0 ? ((cacheHit / cacheTotal) * 100).toFixed(0) : 'n/a';
+}
+
+function summarizeVisionResolution(
+	inputMessages: readonly vscode.LanguageModelChatRequestMessage[],
+	resolvedMessages: readonly vscode.LanguageModelChatRequestMessage[],
+	visionModelId: string | undefined,
+): VisionResolutionStats {
+	const stats: VisionResolutionStats = {
+		inputImageParts: 0,
+		inputImageMessages: 0,
+		describedImageMessages: 0,
+		failedImageMessages: 0,
+		droppedImageParts: 0,
+		descriptionCacheEnabled: false,
+		descriptionCacheHits: 0,
+		descriptionCacheMisses: 0,
+		descriptionCacheEntries: 0,
+		visionModelId,
+	};
+
+	for (const [index, message] of inputMessages.entries()) {
+		const imageParts = countImageDataParts(message);
+		if (imageParts > 0) {
+			stats.inputImageMessages += 1;
+			stats.inputImageParts += imageParts;
+
+			const resolvedMessage = resolvedMessages[index];
+			const resolvedImageParts = resolvedMessage ? countImageDataParts(resolvedMessage) : 0;
+			const inputText = getMessageText(message);
+			const resolvedText = resolvedMessage ? getMessageText(resolvedMessage) : '';
+			const newDescriptions = Math.max(
+				0,
+				countLiteral(resolvedText, '[Image Description:') -
+					countLiteral(inputText, '[Image Description:'),
+			);
+			const newFailures = Math.max(
+				0,
+				countLiteral(resolvedText, '[Image: unable to describe]') -
+					countLiteral(inputText, '[Image: unable to describe]'),
+			);
+
+			if (newDescriptions > 0) {
+				stats.describedImageMessages += 1;
+				stats.descriptionCacheMisses += 1;
+			}
+			if (newFailures > 0) {
+				stats.failedImageMessages += 1;
+			}
+			if (resolvedImageParts < imageParts && newDescriptions === 0 && newFailures === 0) {
+				stats.droppedImageParts += imageParts - resolvedImageParts;
+			}
+		}
+	}
+
+	return stats;
+}
+
+function countImageDataParts(message: vscode.LanguageModelChatRequestMessage): number {
+	return message.content.filter((part) => isImageDataPart(part)).length;
+}
+
+function isImageDataPart(part: unknown): part is vscode.LanguageModelDataPart {
+	return part instanceof vscode.LanguageModelDataPart && part.mimeType.startsWith('image/');
+}
+
+function getMessageText(message: vscode.LanguageModelChatRequestMessage): string {
+	let text = '';
+	for (const part of message.content) {
+		if (part instanceof vscode.LanguageModelTextPart) {
+			text += part.value;
+		}
+	}
+	return text;
+}
+
+function formatVisionTrace(
+	stats: VisionResolutionStats,
+	historyDescriptionMessages: number,
+): string | undefined {
+	if (stats.inputImageParts === 0 && historyDescriptionMessages === 0) {
+		return undefined;
+	}
+
+	const note =
+		stats.inputImageParts === 0 && historyDescriptionMessages > 0 ? ' note=history-only' : '';
+	const visionModel = formatVisionModel(stats);
+	return (
+		`vision rawImageParts=${stats.inputImageParts}` +
+		` rawImageMessages=${stats.inputImageMessages}` +
+		` newDescriptionMessages=${stats.describedImageMessages}` +
+		` failedDescriptionMessages=${stats.failedImageMessages}` +
+		` droppedImageParts=${stats.droppedImageParts}` +
+		` descriptionCache(enabled=${stats.descriptionCacheEnabled},hits=${stats.descriptionCacheHits},misses=${stats.descriptionCacheMisses},entries=${stats.descriptionCacheEntries})` +
+		` visionModel=${visionModel}` +
+		` historyDescriptionMessages=${historyDescriptionMessages}` +
+		note
+	);
+}
+
+function formatVisionModel(stats: VisionResolutionStats): string {
+	if (stats.visionModelId) {
+		return stats.visionModelId;
+	}
+	if (stats.inputImageParts === 0) {
+		return 'none';
+	}
+	if (
+		stats.droppedImageParts > 0 &&
+		stats.describedImageMessages === 0 &&
+		stats.failedImageMessages === 0
+	) {
+		return 'none';
+	}
+	return 'unknown';
+}
+
+export function createCacheTraceSnapshot(request: DeepSeekRequest): CacheTraceSnapshot {
+	const cacheInput = {
+		model: request.model,
+		tools: request.tools ?? null,
+		tool_choice: request.tool_choice ?? null,
+		thinking: request.thinking ?? null,
+		reasoning_effort: request.reasoning_effort ?? null,
+		messages: request.messages,
+	};
+	const serializedInput = stableStringify(cacheInput);
+	const toolsSerialized = stableStringify(request.tools ?? []);
+	const messageSummaries = summarizeMessages(request.messages);
+	const toolSummaries = summarizeTools(request.tools ?? []);
+	const firstMessage = messageSummaries[0];
+
+	return {
+		fingerprint: hashString(serializedInput),
+		conversationKey: hashString(`${request.model}:${firstMessage?.hash ?? 'empty'}`),
+		serializedInput,
+		toolsHash: hashString(toolsSerialized),
+		toolNames: request.tools?.map((tool) => tool.function.name) ?? [],
+		toolSummaries,
+		messageSummaries,
+		stats: summarizeStats(request.messages, request.tools?.length ?? 0),
+	};
+}
+
+export function compareCacheTraceSnapshots(
+	previous: CacheTraceSnapshot | undefined,
+	current: CacheTraceSnapshot,
+): CacheTraceComparison | undefined {
+	if (!previous) {
+		return undefined;
+	}
+
+	const commonPrefixChars = countCommonPrefixChars(
+		previous.serializedInput,
+		current.serializedInput,
+	);
+	const firstChangedMessageIndex = findFirstChangedMessageIndex(
+		previous.messageSummaries,
+		current.messageSummaries,
+	);
+	const firstChangedToolIndex = findFirstChangedToolIndex(
+		previous.toolSummaries,
+		current.toolSummaries,
+	);
+
+	return {
+		commonPrefixChars,
+		commonPrefixPercent:
+			current.serializedInput.length > 0
+				? (commonPrefixChars / current.serializedInput.length) * 100
+				: 100,
+		previousMessageCount: previous.messageSummaries.length,
+		currentMessageCount: current.messageSummaries.length,
+		firstChangedMessageIndex,
+		previousMessage:
+			firstChangedMessageIndex === undefined
+				? undefined
+				: previous.messageSummaries[firstChangedMessageIndex],
+		currentMessage:
+			firstChangedMessageIndex === undefined
+				? undefined
+				: current.messageSummaries[firstChangedMessageIndex],
+		toolsChanged: previous.toolsHash !== current.toolsHash,
+		previousToolsHash: previous.toolsHash,
+		currentToolsHash: current.toolsHash,
+		firstChangedToolIndex,
+		previousTool:
+			firstChangedToolIndex === undefined
+				? undefined
+				: previous.toolSummaries[firstChangedToolIndex],
+		currentTool:
+			firstChangedToolIndex === undefined
+				? undefined
+				: current.toolSummaries[firstChangedToolIndex],
+	};
+}
+
+export function formatCacheTraceSnapshot(snapshot: CacheTraceSnapshot): string {
+	const stats = snapshot.stats;
+	return (
+		`fingerprint=${snapshot.fingerprint} conversation=${snapshot.conversationKey}` +
+		` messages=${stats.messageCount} tools=${stats.toolCount}` +
+		` chars(content=${stats.totalContentChars},toolArgs=${stats.toolCallArgumentChars},reasoning=${stats.reasoningChars})` +
+		` assistantToolMessages=${stats.assistantToolCallMessages}` +
+		` toolReasoning(nonEmpty=${stats.nonEmptyToolReasoningMessages},empty=${stats.emptyToolReasoningMessages},missing=${stats.missingToolReasoningMessages})` +
+		` missingToolReasoning=${stats.missingToolReasoningMessages}` +
+		` assistantAfterToolResult=${stats.assistantAfterToolResultMessages}` +
+		` postToolReasoning(nonEmpty=${stats.nonEmptyPostToolReasoningMessages},empty=${stats.emptyPostToolReasoningMessages},missing=${stats.missingPostToolReasoningMessages})` +
+		` missingPostToolReasoning=${stats.missingPostToolReasoningMessages}` +
+		` imageDescriptions=${stats.imageDescriptionMessages}` +
+		` toolNames=${formatToolNames(snapshot.toolNames)}`
+	);
+}
+
+export function formatCacheTraceDetailLines(snapshot: CacheTraceSnapshot): string[] {
+	const stats = snapshot.stats;
+	return [
+		`roles user=${stats.userMessages} assistant=${stats.assistantMessages} tool=${stats.toolMessages} system=${stats.systemMessages}` +
+			` largeMessages>${LARGE_MESSAGE_CHARS}=${stats.largeMessages}` +
+			` largest=${formatLargestMessages(snapshot.messageSummaries)}`,
+		`markers imageDescMsgs=${stats.imageDescriptionMessages}` +
+			` imageDescParts=${stats.imageDescriptionParts}` +
+			` unableImageMsgs=${stats.unableImageMessages}` +
+			` urlMsgs=${stats.urlMessages}` +
+			` urlCount=${stats.urlCount}` +
+			` codeFenceMsgs=${stats.codeFenceMessages}` +
+			` codeFenceCount=${stats.codeFenceCount}` +
+			` likelyPathMsgs=${stats.likelyPathMessages}` +
+			` likelyPathCount=${stats.likelyPathCount}`,
+	];
+}
+
+export function formatCacheTraceComparison(comparison: CacheTraceComparison): string {
+	const changedMessage =
+		comparison.firstChangedMessageIndex === undefined
+			? 'none'
+			: `${comparison.firstChangedMessageIndex} prev=${formatMessageSummary(
+					comparison.previousMessage,
+				)} curr=${formatMessageSummary(comparison.currentMessage)}`;
+	const changedTool = comparison.toolsChanged
+		? ` firstChangedTool=${formatChangedTool(comparison)}`
+		: '';
+
+	return (
+		`prefixVsPrevious chars=${comparison.commonPrefixChars}` +
+		` percent=${comparison.commonPrefixPercent.toFixed(1)}%` +
+		` toolsChanged=${comparison.toolsChanged}` +
+		` toolsHash=${comparison.previousToolsHash}->${comparison.currentToolsHash}` +
+		changedTool +
+		` firstChangedMessage=${changedMessage}`
+	);
+}
+
+export function formatCacheTraceConversationChangeComparison(
+	previousConversationKey: string,
+	currentConversationKey: string,
+	comparison: CacheTraceComparison,
+): string {
+	const changedMessage =
+		comparison.firstChangedMessageIndex === undefined
+			? 'none'
+			: `${comparison.firstChangedMessageIndex} prev=${formatMessageSummary(
+					comparison.previousMessage,
+				)} curr=${formatMessageSummary(comparison.currentMessage)}`;
+	const changedTool = comparison.toolsChanged
+		? ` firstChangedTool=${formatChangedTool(comparison)}`
+		: '';
+
+	return (
+		`conversationChanged=true prev=${previousConversationKey} curr=${currentConversationKey}` +
+		` fallbackPrefixVsPrevious chars=${comparison.commonPrefixChars}` +
+		` percent=${comparison.commonPrefixPercent.toFixed(1)}%` +
+		` toolsChanged=${comparison.toolsChanged}` +
+		` toolsHash=${comparison.previousToolsHash}->${comparison.currentToolsHash}` +
+		changedTool +
+		` firstChangedMessage=${changedMessage}`
+	);
+}
+
+export function formatCacheTraceComparisonDetailLines(comparison: CacheTraceComparison): string[] {
+	if (
+		comparison.firstChangedMessageIndex === undefined ||
+		!comparison.previousMessage ||
+		!comparison.currentMessage
+	) {
+		return [];
+	}
+
+	const previous = comparison.previousMessage;
+	const current = comparison.currentMessage;
+	return [
+		`changedMessage position=index${comparison.firstChangedMessageIndex}` +
+			` fromEndPrev=${comparison.previousMessageCount - comparison.firstChangedMessageIndex - 1}` +
+			` fromEndCurr=${comparison.currentMessageCount - comparison.firstChangedMessageIndex - 1}` +
+			` delta(chars=${current.contentChars - previous.contentChars}` +
+			`,lines=${current.contentLines - previous.contentLines}` +
+			`,toolArgs=${current.toolCallArgumentChars - previous.toolCallArgumentChars}` +
+			`,reasoning=${current.reasoningChars - previous.reasoningChars})`,
+		`changedMessage hashes content=${previous.contentHash}->${current.contentHash}` +
+			` head=${previous.contentHeadHash}->${current.contentHeadHash}` +
+			` tail=${previous.contentTailHash}->${current.contentTailHash}`,
+		`changedMessage markers prev=${formatMarkerSummary(previous)}` +
+			` curr=${formatMarkerSummary(current)}`,
+	];
+}
+
+export function getCacheTraceWarnings(snapshot: CacheTraceSnapshot): string[] {
+	const warnings: string[] = [];
+	if (snapshot.stats.missingToolReasoningMessages > 0) {
+		warnings.push(
+			`${snapshot.stats.missingToolReasoningMessages} assistant tool-call message(s) are missing cached reasoning_content; DeepSeek requires this in thinking tool-call histories and cache prefixes may drift.`,
+		);
+	}
+	if (snapshot.stats.missingPostToolReasoningMessages > 0) {
+		warnings.push(
+			`${snapshot.stats.missingPostToolReasoningMessages} assistant message(s) after tool results are missing cached reasoning_content; DeepSeek requires final tool-call-turn reasoning in subsequent requests.`,
+		);
+	}
+	const emptyReasoningMessages =
+		snapshot.stats.emptyToolReasoningMessages + snapshot.stats.emptyPostToolReasoningMessages;
+	if (emptyReasoningMessages > 0) {
+		warnings.push(
+			`${emptyReasoningMessages} reasoning-required assistant message reference(s) have empty reasoning_content fallback; this is protocol-safe but may indicate the original reasoning cache was unavailable after extension restart/reload.`,
+		);
+	}
+	if (snapshot.stats.imageDescriptionMessages > 0) {
+		warnings.push(
+			`${snapshot.stats.imageDescriptionMessages} message(s) already contain generated image-description text in request history; check the vision trace rawImageParts field to see whether this request actually processed image data.`,
+		);
+	}
+	return warnings;
+}
+
+export function getCacheTraceComparisonWarnings(comparison: CacheTraceComparison): string[] {
+	const warnings: string[] = [];
+	if (
+		comparison.firstChangedMessageIndex !== undefined &&
+		comparison.previousMessage &&
+		comparison.currentMessage
+	) {
+		const previousMessagesAfterChange =
+			comparison.previousMessageCount - comparison.firstChangedMessageIndex - 1;
+		if (previousMessagesAfterChange > 2) {
+			warnings.push(
+				`retained history changed before the append boundary at message #${comparison.firstChangedMessageIndex}; ${previousMessagesAfterChange} previous message(s) after it cannot share an identical serialized prefix.`,
+			);
+		}
+		if (
+			comparison.previousMessage.imageDescriptionCount > 0 ||
+			comparison.currentMessage.imageDescriptionCount > 0
+		) {
+			warnings.push(
+				`first changed message contains generated image-description marker(s); if rawImageParts is also non-zero, repeated vision re-description is likely.`,
+			);
+		}
+	}
+	if (comparison.toolsChanged) {
+		warnings.push(
+			`tool schema changed; firstChangedTool=${formatChangedTool(comparison)}. A changed tool list rebuilds the cache prefix before messages.`,
+		);
+	}
+	if (comparison.currentMessageCount < comparison.previousMessageCount) {
+		warnings.push(
+			`message count decreased ${comparison.previousMessageCount}->${comparison.currentMessageCount}; host-side history truncation or compaction may have occurred.`,
+		);
+	}
+	return warnings;
+}
+
+function summarizeMessages(messages: DeepSeekMessage[]): CacheTraceMessageSummary[] {
+	const summaries: CacheTraceMessageSummary[] = [];
+	let followsToolResult = false;
+	for (const [index, message] of messages.entries()) {
+		summaries.push(summarizeMessage(message, index, followsToolResult));
+		if (message.role === 'tool') {
+			followsToolResult = true;
+		} else if (message.role === 'assistant') {
+			followsToolResult = false;
+		}
+	}
+	return summaries;
+}
+
+function summarizeMessage(
+	message: DeepSeekMessage,
+	index: number,
+	followsToolResult: boolean,
+): CacheTraceMessageSummary {
+	const toolCallArgumentChars =
+		message.tool_calls?.reduce((sum, toolCall) => sum + toolCall.function.arguments.length, 0) ?? 0;
+	const reasoningChars = message.reasoning_content?.length ?? 0;
+	const toolCalls = message.tool_calls?.length ?? 0;
+	const assistantAfterToolResult = message.role === 'assistant' && followsToolResult;
+	const hasReasoningContent = message.reasoning_content !== undefined;
+	const hasEmptyReasoningContent = hasReasoningContent && reasoningChars === 0;
+	const imageDescriptionCount = countLiteral(message.content, '[Image Description:');
+	const unableImageCount = countLiteral(message.content, '[Image: unable to describe]');
+	const urlCount = countRegex(message.content, /https?:\/\//g);
+	const codeFenceCount = countLiteral(message.content, '```');
+	const likelyPathCount = countLikelyPaths(message.content);
+
+	return {
+		index,
+		role: message.role,
+		hash: hashString(stableStringify(message)),
+		contentHash: hashString(message.content),
+		contentHeadHash: hashString(message.content.slice(0, HASH_WINDOW_CHARS)),
+		contentTailHash: hashString(message.content.slice(-HASH_WINDOW_CHARS)),
+		contentChars: message.content.length,
+		contentLines: countLines(message.content),
+		imageDescriptionCount,
+		unableImageCount,
+		urlCount,
+		codeFenceCount,
+		likelyPathCount,
+		toolCalls,
+		toolCallArgumentChars,
+		reasoningChars,
+		emptyReasoning: hasEmptyReasoningContent,
+		missingToolReasoning: message.role === 'assistant' && toolCalls > 0 && !hasReasoningContent,
+		followsToolResult: assistantAfterToolResult,
+		missingPostToolReasoning: assistantAfterToolResult && !hasReasoningContent,
+	};
+}
+
+function summarizeTools(tools: DeepSeekTool[]): CacheTraceToolSummary[] {
+	return tools.map((tool, index) => ({
+		index,
+		name: tool.function.name,
+		hash: hashString(stableStringify(tool)),
+		descriptionHash: hashString(tool.function.description ?? ''),
+		parametersHash: hashString(stableStringify(tool.function.parameters ?? null)),
+	}));
+}
+
+function summarizeStats(messages: DeepSeekMessage[], toolCount: number): CacheTraceStats {
+	let userMessages = 0;
+	let assistantMessages = 0;
+	let toolMessages = 0;
+	let systemMessages = 0;
+	let totalContentChars = 0;
+	let toolCallArgumentChars = 0;
+	let reasoningChars = 0;
+	let largeMessages = 0;
+	let assistantToolCallMessages = 0;
+	let nonEmptyToolReasoningMessages = 0;
+	let emptyToolReasoningMessages = 0;
+	let missingToolReasoningMessages = 0;
+	let assistantAfterToolResultMessages = 0;
+	let nonEmptyPostToolReasoningMessages = 0;
+	let emptyPostToolReasoningMessages = 0;
+	let missingPostToolReasoningMessages = 0;
+	let imageDescriptionMessages = 0;
+	let imageDescriptionParts = 0;
+	let unableImageMessages = 0;
+	let urlMessages = 0;
+	let urlCount = 0;
+	let codeFenceMessages = 0;
+	let codeFenceCount = 0;
+	let likelyPathMessages = 0;
+	let likelyPathCount = 0;
+	let followsToolResult = false;
+
+	for (const message of messages) {
+		if (message.role === 'user') {
+			userMessages += 1;
+		} else if (message.role === 'assistant') {
+			assistantMessages += 1;
+		} else if (message.role === 'tool') {
+			toolMessages += 1;
+		} else if (message.role === 'system') {
+			systemMessages += 1;
+		}
+
+		totalContentChars += message.content.length;
+		if (message.content.length > LARGE_MESSAGE_CHARS) {
+			largeMessages += 1;
+		}
+
+		const imageDescriptions = countLiteral(message.content, '[Image Description:');
+		if (imageDescriptions > 0) {
+			imageDescriptionMessages += 1;
+			imageDescriptionParts += imageDescriptions;
+		}
+		if (message.content.includes('[Image: unable to describe]')) {
+			unableImageMessages += 1;
+		}
+
+		const messageUrlCount = countRegex(message.content, /https?:\/\//g);
+		if (messageUrlCount > 0) {
+			urlMessages += 1;
+			urlCount += messageUrlCount;
+		}
+
+		const messageCodeFenceCount = countLiteral(message.content, '```');
+		if (messageCodeFenceCount > 0) {
+			codeFenceMessages += 1;
+			codeFenceCount += messageCodeFenceCount;
+		}
+
+		const messageLikelyPathCount = countLikelyPaths(message.content);
+		if (messageLikelyPathCount > 0) {
+			likelyPathMessages += 1;
+			likelyPathCount += messageLikelyPathCount;
+		}
+
+		const toolCalls = message.tool_calls?.length ?? 0;
+		const messageReasoningChars = message.reasoning_content?.length ?? 0;
+		if (message.role === 'assistant' && followsToolResult) {
+			assistantAfterToolResultMessages += 1;
+			if (message.reasoning_content === undefined) {
+				missingPostToolReasoningMessages += 1;
+			} else if (messageReasoningChars === 0) {
+				emptyPostToolReasoningMessages += 1;
+			} else {
+				nonEmptyPostToolReasoningMessages += 1;
+			}
+		}
+
+		if (toolCalls > 0) {
+			assistantToolCallMessages += 1;
+			if (message.reasoning_content === undefined) {
+				missingToolReasoningMessages += 1;
+			} else if (messageReasoningChars === 0) {
+				emptyToolReasoningMessages += 1;
+			} else {
+				nonEmptyToolReasoningMessages += 1;
+			}
+			for (const toolCall of message.tool_calls ?? []) {
+				toolCallArgumentChars += toolCall.function.arguments.length;
+			}
+		}
+
+		reasoningChars += messageReasoningChars;
+
+		if (message.role === 'tool') {
+			followsToolResult = true;
+		} else if (message.role === 'assistant') {
+			followsToolResult = false;
+		}
+	}
+
+	return {
+		messageCount: messages.length,
+		userMessages,
+		assistantMessages,
+		toolMessages,
+		systemMessages,
+		toolCount,
+		totalContentChars,
+		toolCallArgumentChars,
+		reasoningChars,
+		largeMessages,
+		assistantToolCallMessages,
+		nonEmptyToolReasoningMessages,
+		emptyToolReasoningMessages,
+		missingToolReasoningMessages,
+		assistantAfterToolResultMessages,
+		nonEmptyPostToolReasoningMessages,
+		emptyPostToolReasoningMessages,
+		missingPostToolReasoningMessages,
+		imageDescriptionMessages,
+		imageDescriptionParts,
+		unableImageMessages,
+		urlMessages,
+		urlCount,
+		codeFenceMessages,
+		codeFenceCount,
+		likelyPathMessages,
+		likelyPathCount,
+	};
+}
+
+function formatMessageSummary(summary: CacheTraceMessageSummary | undefined): string {
+	if (!summary) {
+		return 'missing';
+	}
+	return (
+		`${summary.role}#${summary.index}` +
+		` hash=${summary.hash}` +
+		` contentHash=${summary.contentHash}` +
+		` chars=${summary.contentChars}` +
+		` lines=${summary.contentLines}` +
+		` toolCalls=${summary.toolCalls}` +
+		` toolArgs=${summary.toolCallArgumentChars}` +
+		` reasoning=${summary.reasoningChars}` +
+		` emptyReasoning=${summary.emptyReasoning}` +
+		` markers=${formatMarkerSummary(summary)}` +
+		` followsToolResult=${summary.followsToolResult}`
+	);
+}
+
+function formatMarkerSummary(summary: CacheTraceMessageSummary): string {
+	return (
+		`imageDesc=${summary.imageDescriptionCount}` +
+		`,unableImage=${summary.unableImageCount}` +
+		`,url=${summary.urlCount}` +
+		`,codeFence=${summary.codeFenceCount}` +
+		`,likelyPath=${summary.likelyPathCount}`
+	);
+}
+
+function formatLargestMessages(messageSummaries: CacheTraceMessageSummary[]): string {
+	const largest = [...messageSummaries]
+		.sort((left, right) => right.contentChars - left.contentChars)
+		.slice(0, 5)
+		.map(
+			(summary) =>
+				`${summary.role}#${summary.index}:chars=${summary.contentChars},hash=${summary.contentHash},markers=${formatMarkerSummary(summary)}`,
+		);
+	return largest.length > 0 ? largest.join(';') : 'none';
+}
+
+function formatToolNames(toolNames: string[]): string {
+	if (toolNames.length === 0) {
+		return 'none';
+	}
+	const shown = toolNames.slice(0, 10).join(',');
+	return toolNames.length > 10 ? `${shown},+${toolNames.length - 10}` : shown;
+}
+
+function formatChangedTool(comparison: CacheTraceComparison): string {
+	if (comparison.firstChangedToolIndex === undefined) {
+		return 'none';
+	}
+	return (
+		`${comparison.firstChangedToolIndex}` +
+		` prev=${formatToolSummary(comparison.previousTool)}` +
+		` curr=${formatToolSummary(comparison.currentTool)}`
+	);
+}
+
+function formatToolSummary(summary: CacheTraceToolSummary | undefined): string {
+	if (!summary) {
+		return 'missing';
+	}
+	return (
+		`${summary.name}#${summary.index}` +
+		` hash=${summary.hash}` +
+		` desc=${summary.descriptionHash}` +
+		` params=${summary.parametersHash}`
+	);
+}
+
+function findFirstChangedMessageIndex(
+	previous: CacheTraceMessageSummary[],
+	current: CacheTraceMessageSummary[],
+): number | undefined {
+	const maxLength = Math.max(previous.length, current.length);
+	for (let index = 0; index < maxLength; index += 1) {
+		if (previous[index]?.hash !== current[index]?.hash) {
+			return index;
+		}
+	}
+	return undefined;
+}
+
+function findFirstChangedToolIndex(
+	previous: CacheTraceToolSummary[],
+	current: CacheTraceToolSummary[],
+): number | undefined {
+	const maxLength = Math.max(previous.length, current.length);
+	for (let index = 0; index < maxLength; index += 1) {
+		if (previous[index]?.hash !== current[index]?.hash) {
+			return index;
+		}
+	}
+	return undefined;
+}
+
+function countCommonPrefixChars(a: string, b: string): number {
+	const length = Math.min(a.length, b.length);
+	let index = 0;
+	while (index < length && a.charCodeAt(index) === b.charCodeAt(index)) {
+		index += 1;
+	}
+	return index;
+}
+
+function countLiteral(value: string, needle: string): number {
+	if (!needle) {
+		return 0;
+	}
+	let count = 0;
+	let index = value.indexOf(needle);
+	while (index !== -1) {
+		count += 1;
+		index = value.indexOf(needle, index + needle.length);
+	}
+	return count;
+}
+
+function countRegex(value: string, regex: RegExp): number {
+	return value.match(regex)?.length ?? 0;
+}
+
+function countLikelyPaths(value: string): number {
+	return countRegex(value, /(?:^|\s)(?:[\w.-]+\/){1,}[\w.-]+/g);
+}
+
+function countLines(value: string): number {
+	if (value.length === 0) {
+		return 0;
+	}
+	return countLiteral(value, '\n') + 1;
+}
+
+function stableStringify(value: unknown): string {
+	if (value === null || typeof value !== 'object') {
+		return JSON.stringify(value);
+	}
+
+	if (Array.isArray(value)) {
+		return `[${value.map((item) => stableStringify(item)).join(',')}]`;
+	}
+
+	const entries = Object.entries(value as Record<string, unknown>)
+		.filter(([, entryValue]) => entryValue !== undefined)
+		.sort(([left], [right]) => left.localeCompare(right));
+	return `{${entries
+		.map(([key, entryValue]) => `${JSON.stringify(key)}:${stableStringify(entryValue)}`)
+		.join(',')}}`;
+}
+
+function hashString(value: string): string {
+	return createHash('sha256').update(value).digest('hex').slice(0, 12);
+}

--- a/src/provider/index.ts
+++ b/src/provider/index.ts
@@ -1,55 +1,15 @@
 import vscode from 'vscode';
 import { AuthManager } from '../auth';
-import { DeepSeekClient } from '../client';
-import { getApiModelId, getBaseUrl, getMaxTokens } from '../config';
 import { MODELS } from '../consts';
 import { t } from '../i18n';
 import { logger } from '../logger';
-import type { DeepSeekToolCall, ModelDefinition } from '../types';
-import { type ReasoningEntry, pruneReasoningCache } from './cache';
-import { convertMessages, convertTools, countMessageChars } from './convert';
-import { createVisionModelGetter, resolveImageMessages, setVisionProxyModel } from './vision';
-
-/**
- * NOTE: Non-public API surface.
- *
- * The fields below (`configurationSchema` on chat info, `modelConfiguration`
- * on response options, plus `isUserSelectable` / `statusIcon`) are not part
- * of the stable `vscode.LanguageModelChat*` typings yet. They are the same
- * shape currently consumed by GitHub Copilot Chat to render a per-model
- * config dropdown in the model picker (see Copilot Chat's built-in
- * providers, e.g. its OpenAI/Anthropic providers using `reasoningEffort`).
- *
- * If/when VS Code stabilizes these as proposed API, switch to the official
- * types and drop the casts below.
- */
-
-type ThinkingEffort = 'none' | 'high' | 'max';
-
-/**
- * Non-public: Copilot Chat passes the user's per-model picker selections
- * back to providers via `modelConfiguration` (newer hosts) / `configuration`
- * (older hosts) on the response options. Both names are checked at runtime.
- */
-type ModelConfigurationOptions = vscode.ProvideLanguageModelChatResponseOptions & {
-	readonly modelConfiguration?: Record<string, unknown>;
-	readonly configuration?: Record<string, unknown>;
-};
-
-/**
- * Non-public: extra fields on `LanguageModelChatInformation` consumed by the
- * Copilot Chat model picker — `isUserSelectable` controls picker visibility,
- * `statusIcon` renders a leading icon (e.g. warning when key missing), and
- * `configurationSchema` declares the per-model dropdown schema.
- */
-/** Shape of the per-model configuration schema rendered by Copilot Chat's model picker. */
-type ThinkingEffortConfigurationSchema = ReturnType<typeof buildThinkingEffortSchema>;
-
-type ModelPickerChatInformation = vscode.LanguageModelChatInformation & {
-	readonly isUserSelectable: boolean;
-	readonly statusIcon?: vscode.ThemeIcon;
-	readonly configurationSchema?: ThinkingEffortConfigurationSchema;
-};
+import type { ReasoningEntry } from './cache';
+import { createCacheDiagnosticsRecorder } from './diagnostics';
+import { toChatInfo } from './models';
+import { prepareChatRequest } from './request';
+import { streamChatCompletion } from './stream';
+import { estimateTokenCount } from './tokens';
+import { createVisionModelGetter, setVisionProxyModel } from './vision';
 
 /**
  * DeepSeek Chat Provider — implements vscode.LanguageModelChatProvider so
@@ -65,6 +25,7 @@ export class DeepSeekChatProvider implements vscode.LanguageModelChatProvider {
 
 	/** reasoning text → tool_call IDs cache. */
 	private readonly reasoningCache = new Map<string, ReasoningEntry>();
+	private readonly cacheDiagnostics = createCacheDiagnosticsRecorder();
 
 	/** Vision proxy: resolver + cached model. */
 	private readonly vision = createVisionModelGetter();
@@ -167,138 +128,26 @@ export class DeepSeekChatProvider implements vscode.LanguageModelChatProvider {
 		progress: vscode.Progress<vscode.LanguageModelResponsePart>,
 		token: vscode.CancellationToken,
 	): Promise<void> {
-		const apiKey = await this.authManager.getApiKey();
-		if (!apiKey) {
-			throw new Error(t('auth.notConfigured'));
-		}
+		const prepared = await prepareChatRequest({
+			authManager: this.authManager,
+			modelInfo,
+			messages,
+			options,
+			token,
+			reasoningCache: this.reasoningCache,
+			cacheDiagnostics: this.cacheDiagnostics,
+			getVisionModel: () => this.vision.get(),
+		});
 
-		const baseUrl = getBaseUrl();
-		const client = new DeepSeekClient(baseUrl, apiKey);
-
-		const modelDef = MODELS.find((m) => m.id === modelInfo.id);
-		const isThinkingModel = modelDef?.capabilities.thinking ?? false;
-		const thinkingEffort = getConfiguredThinkingEffort(options as ModelConfigurationOptions);
-		const maxTokens = getMaxTokens();
-
-		// Heuristic: detect conversation start to clear stale cache.
-		if (messages.length <= 2) {
-			pruneReasoningCache(this.reasoningCache, true);
-		}
-
-		// Vision proxy: resolve images → text descriptions before sending to DeepSeek
-		const resolvedMessages = await resolveImageMessages(messages, token, () => this.vision.get());
-		const deepseekMessages = convertMessages(
-			resolvedMessages,
-			isThinkingModel,
-			this.reasoningCache,
-		);
-		const tools = modelDef?.capabilities.toolCalling ? convertTools(options.tools) : undefined;
-
-		const totalRequestChars = countMessageChars(deepseekMessages);
-
-		let accumulatedReasoning = '';
-		const pendingToolCallIds: string[] = [];
-		let responseMessageId: string | undefined;
-
-		return new Promise<void>((resolve, reject) => {
-			client.streamChatCompletion(
-				{
-					model: getApiModelId(modelInfo.id),
-					messages: deepseekMessages,
-					stream: true,
-					tools,
-					tool_choice: tools && tools.length > 0 ? 'auto' : undefined,
-					max_tokens: maxTokens,
-					...(isThinkingModel
-						? {
-								thinking: {
-									type: thinkingEffort === 'none' ? ('disabled' as const) : ('enabled' as const),
-								},
-								...(thinkingEffort === 'none' ? {} : { reasoning_effort: thinkingEffort }),
-							}
-						: {}),
-				},
-				{
-					onContent: (content: string) => {
-						progress.report(new vscode.LanguageModelTextPart(content));
-					},
-
-					onThinking: (text: string) => {
-						accumulatedReasoning += text;
-
-						// LanguageModelThinkingPart is a proposed API — the class
-						// exists at runtime in both stable and Insiders, but the
-						// stable vscode.d.ts doesn't include it. The .d.ts
-						// augmentation in the project root provides type safety.
-						progress.report(
-							new vscode.LanguageModelThinkingPart(
-								text,
-							) as unknown as vscode.LanguageModelResponsePart,
-						);
-					},
-
-					onToolCall: (toolCall: DeepSeekToolCall) => {
-						pendingToolCallIds.push(toolCall.id);
-
-						// Cache reasoning keyed by tool_call ID
-						if (isThinkingModel && accumulatedReasoning) {
-							this.reasoningCache.set(toolCall.id, {
-								text: accumulatedReasoning,
-								timestamp: Date.now(),
-							});
-						}
-
-						try {
-							const args = JSON.parse(toolCall.function.arguments);
-							progress.report(
-								new vscode.LanguageModelToolCallPart(toolCall.id, toolCall.function.name, args),
-							);
-						} catch {
-							progress.report(
-								new vscode.LanguageModelToolCallPart(toolCall.id, toolCall.function.name, {}),
-							);
-						}
-					},
-
-					onError: (error: Error) => {
-						reject(error);
-					},
-
-					onDone: () => {
-						// Cache reasoning for the final response (non-tool-call case).
-						if (isThinkingModel && accumulatedReasoning && pendingToolCallIds.length === 0) {
-							responseMessageId = `resp_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`;
-							this.reasoningCache.set(responseMessageId, {
-								text: accumulatedReasoning,
-								timestamp: Date.now(),
-							});
-						}
-
-						pruneReasoningCache(this.reasoningCache, false);
-						resolve();
-					},
-
-					onUsage: (usage) => {
-						// Calibrate chars-per-token ratio from real API usage data.
-						if (totalRequestChars > 0 && usage.prompt_tokens > 0) {
-							const observedRatio = totalRequestChars / usage.prompt_tokens;
-							this.charsPerToken = this.charsPerToken * 0.7 + observedRatio * 0.3;
-						}
-
-						// Log KV cache hit stats for observability.
-						const cacheHit = usage.prompt_cache_hit_tokens ?? 0;
-						const cacheMiss = usage.prompt_cache_miss_tokens ?? 0;
-						const cacheTotal = cacheHit + cacheMiss;
-						const hitRate = cacheTotal > 0 ? ((cacheHit / cacheTotal) * 100).toFixed(0) : 'n/a';
-						logger.info(
-							`tokens: prompt=${usage.prompt_tokens} completion=${usage.completion_tokens}` +
-								` | cache: hit=${cacheHit} miss=${cacheMiss} rate=${hitRate}%` +
-								` | chars/tok=${this.charsPerToken.toFixed(2)}`,
-						);
-					},
-				},
-				token,
-			);
+		return streamChatCompletion({
+			prepared,
+			progress,
+			token,
+			reasoningCache: this.reasoningCache,
+			getCharsPerToken: () => this.charsPerToken,
+			setCharsPerToken: (charsPerToken) => {
+				this.charsPerToken = charsPerToken;
+			},
 		});
 	}
 
@@ -307,100 +156,6 @@ export class DeepSeekChatProvider implements vscode.LanguageModelChatProvider {
 		text: string | vscode.LanguageModelChatRequestMessage,
 		_token: vscode.CancellationToken,
 	): Promise<number> {
-		if (typeof text === 'string') {
-			return Math.max(1, Math.ceil(text.length / this.charsPerToken));
-		}
-
-		if (!text?.content || !Array.isArray(text.content)) {
-			return 1;
-		}
-
-		let total = 0;
-		for (const part of text.content) {
-			if (part instanceof vscode.LanguageModelTextPart) {
-				total += part.value.length;
-			}
-		}
-		return Math.max(1, Math.ceil(total / this.charsPerToken));
+		return estimateTokenCount(text, this.charsPerToken);
 	}
-}
-
-// ---- Helpers ----
-
-/**
- * Build the thinking effort configuration schema with translated labels.
- * Called inside toChatInfo() so translations reflect the current locale.
- */
-function buildThinkingEffortSchema() {
-	return {
-		properties: {
-			reasoningEffort: {
-				type: 'string',
-				title: t('status.thinking'),
-				enum: ['none', 'high', 'max'],
-				enumItemLabels: [t('thinking.none'), t('thinking.high'), t('thinking.max')],
-				enumDescriptions: [
-					t('thinking.none.desc'),
-					t('thinking.high.desc'),
-					t('thinking.max.desc'),
-				],
-				default: 'high',
-				group: 'navigation',
-			},
-		},
-	} as const;
-}
-
-/**
- * Derive the i18n key for a model's detail line from the model ID.
- * Returns `undefined` when the key is missing from *both* locales —
- * `toChatInfo()` will then fall back to `m.detail`. When the key exists
- * in English but not the active locale, the English translation is used
- * (per `t()`'s fallback behaviour).
- */
-function resolveDetailKey(m: ModelDefinition): string | undefined {
-	// Map known DeepSeek V4 models: deepseek-v4-flash → model.flash.detail
-	const suffix = m.id.startsWith('deepseek-v4-') ? m.id.slice('deepseek-v4-'.length) : m.id;
-	const key = `model.${suffix}.detail`;
-	// t() returns the raw key string when no translation is defined in either
-	// locale — treat that as "no translation available" and fall back.
-	const translated = t(key);
-	return translated !== key ? key : undefined;
-}
-
-function toChatInfo(m: ModelDefinition, hasApiKey: boolean): ModelPickerChatInformation {
-	const detailKey = resolveDetailKey(m);
-	const modelDetail = detailKey ? t(detailKey) : m.detail;
-	return {
-		id: m.id,
-		name: m.name,
-		family: m.family,
-		version: m.version,
-		detail: hasApiKey ? modelDetail : t('auth.apiKeyRequiredDetail'),
-		tooltip: hasApiKey ? undefined : t('auth.apiKeyRequiredDetail'),
-		statusIcon: hasApiKey ? undefined : new vscode.ThemeIcon('warning'),
-		maxInputTokens: m.maxInputTokens,
-		maxOutputTokens: m.maxOutputTokens,
-		isUserSelectable: true,
-		capabilities: {
-			toolCalling: m.capabilities.toolCalling,
-			imageInput: m.capabilities.imageInput,
-		},
-		...(m.capabilities.thinking ? { configurationSchema: buildThinkingEffortSchema() } : {}),
-	};
-}
-
-function getConfiguredThinkingEffort(options: ModelConfigurationOptions): ThinkingEffort {
-	const configuredEffort =
-		options.modelConfiguration?.reasoningEffort ?? options.configuration?.reasoningEffort;
-
-	if (configuredEffort === 'none') {
-		return 'none';
-	}
-
-	if (configuredEffort === 'high') {
-		return 'high';
-	}
-
-	return configuredEffort === 'max' ? 'max' : 'high';
 }

--- a/src/provider/models.ts
+++ b/src/provider/models.ts
@@ -1,0 +1,92 @@
+import vscode from 'vscode';
+import { t } from '../i18n';
+import type { ModelDefinition } from '../types';
+
+/**
+ * NOTE: Non-public API surface.
+ *
+ * The fields below (`configurationSchema` on chat info, `modelConfiguration`
+ * on response options, plus `isUserSelectable` / `statusIcon`) are not part
+ * of the stable `vscode.LanguageModelChat*` typings yet. They are the same
+ * shape currently consumed by GitHub Copilot Chat to render a per-model
+ * config dropdown in the model picker.
+ */
+
+export type ThinkingEffort = 'none' | 'high' | 'max';
+
+export type ModelConfigurationOptions = vscode.ProvideLanguageModelChatResponseOptions & {
+	readonly modelConfiguration?: Record<string, unknown>;
+	readonly configuration?: Record<string, unknown>;
+};
+
+type ThinkingEffortConfigurationSchema = ReturnType<typeof buildThinkingEffortSchema>;
+
+export type ModelPickerChatInformation = vscode.LanguageModelChatInformation & {
+	readonly isUserSelectable: boolean;
+	readonly statusIcon?: vscode.ThemeIcon;
+	readonly configurationSchema?: ThinkingEffortConfigurationSchema;
+};
+
+export function toChatInfo(m: ModelDefinition, hasApiKey: boolean): ModelPickerChatInformation {
+	const detailKey = resolveDetailKey(m);
+	const modelDetail = detailKey ? t(detailKey) : m.detail;
+	return {
+		id: m.id,
+		name: m.name,
+		family: m.family,
+		version: m.version,
+		detail: hasApiKey ? modelDetail : t('auth.apiKeyRequiredDetail'),
+		tooltip: hasApiKey ? undefined : t('auth.apiKeyRequiredDetail'),
+		statusIcon: hasApiKey ? undefined : new vscode.ThemeIcon('warning'),
+		maxInputTokens: m.maxInputTokens,
+		maxOutputTokens: m.maxOutputTokens,
+		isUserSelectable: true,
+		capabilities: {
+			toolCalling: m.capabilities.toolCalling,
+			imageInput: m.capabilities.imageInput,
+		},
+		...(m.capabilities.thinking ? { configurationSchema: buildThinkingEffortSchema() } : {}),
+	};
+}
+
+export function getConfiguredThinkingEffort(options: ModelConfigurationOptions): ThinkingEffort {
+	const configuredEffort =
+		options.modelConfiguration?.reasoningEffort ?? options.configuration?.reasoningEffort;
+
+	if (configuredEffort === 'none') {
+		return 'none';
+	}
+
+	if (configuredEffort === 'high') {
+		return 'high';
+	}
+
+	return configuredEffort === 'max' ? 'max' : 'high';
+}
+
+function buildThinkingEffortSchema() {
+	return {
+		properties: {
+			reasoningEffort: {
+				type: 'string',
+				title: t('status.thinking'),
+				enum: ['none', 'high', 'max'],
+				enumItemLabels: [t('thinking.none'), t('thinking.high'), t('thinking.max')],
+				enumDescriptions: [
+					t('thinking.none.desc'),
+					t('thinking.high.desc'),
+					t('thinking.max.desc'),
+				],
+				default: 'high',
+				group: 'navigation',
+			},
+		},
+	} as const;
+}
+
+function resolveDetailKey(m: ModelDefinition): string | undefined {
+	const suffix = m.id.startsWith('deepseek-v4-') ? m.id.slice('deepseek-v4-'.length) : m.id;
+	const key = `model.${suffix}.detail`;
+	const translated = t(key);
+	return translated !== key ? key : undefined;
+}

--- a/src/provider/request.ts
+++ b/src/provider/request.ts
@@ -1,0 +1,132 @@
+import vscode from 'vscode';
+import { AuthManager } from '../auth';
+import { DeepSeekClient } from '../client';
+import { getApiModelId, getBaseUrl, getMaxTokens } from '../config';
+import { MODELS } from '../consts';
+import { t } from '../i18n';
+import type { DeepSeekRequest } from '../types';
+import { pruneReasoningCache, type ReasoningEntry } from './cache';
+import { convertMessages, convertTools, countMessageChars } from './convert';
+import type { CacheDiagnosticsRecorder, CacheDiagnosticsRun } from './diagnostics';
+import { getConfiguredThinkingEffort, type ModelConfigurationOptions } from './models';
+import { resolveImageMessages } from './vision';
+
+export interface PreparedChatRequest {
+	client: DeepSeekClient;
+	request: DeepSeekRequest;
+	isThinkingModel: boolean;
+	totalRequestChars: number;
+	trailingToolResults: number;
+	cacheDiagnostics: CacheDiagnosticsRun;
+}
+
+export interface PrepareChatRequestOptions {
+	authManager: AuthManager;
+	modelInfo: vscode.LanguageModelChatInformation;
+	messages: readonly vscode.LanguageModelChatRequestMessage[];
+	options: vscode.ProvideLanguageModelChatResponseOptions;
+	token: vscode.CancellationToken;
+	reasoningCache: Map<string, ReasoningEntry>;
+	cacheDiagnostics: CacheDiagnosticsRecorder;
+	getVisionModel: () => Promise<vscode.LanguageModelChat | undefined>;
+}
+
+export async function prepareChatRequest({
+	authManager,
+	modelInfo,
+	messages,
+	options,
+	token,
+	reasoningCache,
+	cacheDiagnostics,
+	getVisionModel,
+}: PrepareChatRequestOptions): Promise<PreparedChatRequest> {
+	const apiKey = await authManager.getApiKey();
+	if (!apiKey) {
+		throw new Error(t('auth.notConfigured'));
+	}
+
+	const client = new DeepSeekClient(getBaseUrl(), apiKey);
+	const modelDef = MODELS.find((m) => m.id === modelInfo.id);
+	const isThinkingModel = modelDef?.capabilities.thinking ?? false;
+	const thinkingEffort = getConfiguredThinkingEffort(options as ModelConfigurationOptions);
+	const maxTokens = getMaxTokens();
+
+	clearStaleReasoningCache(messages, reasoningCache, cacheDiagnostics);
+	const reasoningCacheSize = reasoningCache.size;
+	let visionModelId: string | undefined;
+
+	const resolvedMessages = await resolveImageMessages(messages, token, async () => {
+		const model = await getVisionModel();
+		visionModelId = model?.id;
+		return model;
+	});
+	const deepseekMessages = convertMessages(resolvedMessages, isThinkingModel, reasoningCache);
+	const tools = modelDef?.capabilities.toolCalling ? convertTools(options.tools) : undefined;
+
+	const totalRequestChars = countMessageChars(deepseekMessages);
+	const request: DeepSeekRequest = {
+		model: getApiModelId(modelInfo.id),
+		messages: deepseekMessages,
+		stream: true,
+		tools,
+		tool_choice: tools && tools.length > 0 ? ('auto' as const) : undefined,
+		max_tokens: maxTokens,
+		...(isThinkingModel
+			? {
+					thinking: {
+						type: thinkingEffort === 'none' ? ('disabled' as const) : ('enabled' as const),
+					},
+					...(thinkingEffort === 'none' ? {} : { reasoning_effort: thinkingEffort }),
+				}
+			: {}),
+	};
+	const diagnosticsRun = cacheDiagnostics.beginRequest({
+		request,
+		vscodeModelId: modelInfo.id,
+		isThinkingModel,
+		thinkingEffort,
+		maxTokens,
+		reasoningCacheSize,
+		inputMessages: messages,
+		resolvedMessages,
+		visionModelId,
+	});
+
+	return {
+		client,
+		request,
+		isThinkingModel,
+		totalRequestChars,
+		trailingToolResults: countTrailingToolResults(messages),
+		cacheDiagnostics: diagnosticsRun,
+	};
+}
+
+function countTrailingToolResults(
+	messages: readonly vscode.LanguageModelChatRequestMessage[],
+): number {
+	let trailingToolResults = 0;
+	for (let index = messages.length - 1; index >= 0; index -= 1) {
+		const toolResults = messages[index].content.filter(
+			(part) => part instanceof vscode.LanguageModelToolResultPart,
+		).length;
+		if (toolResults === 0) {
+			break;
+		}
+		trailingToolResults += toolResults;
+	}
+	return trailingToolResults;
+}
+
+function clearStaleReasoningCache(
+	messages: readonly vscode.LanguageModelChatRequestMessage[],
+	reasoningCache: Map<string, ReasoningEntry>,
+	cacheDiagnostics: CacheDiagnosticsRecorder,
+): void {
+	if (messages.length <= 2) {
+		const removed = reasoningCache.size;
+		pruneReasoningCache(reasoningCache, true);
+		cacheDiagnostics.logReasoningCacheCleared(removed);
+	}
+}

--- a/src/provider/stream.ts
+++ b/src/provider/stream.ts
@@ -1,0 +1,155 @@
+import vscode from 'vscode';
+import type { DeepSeekToolCall, DeepSeekUsage } from '../types';
+import { pruneReasoningCache, type ReasoningEntry } from './cache';
+import type { CacheDiagnosticsRun } from './diagnostics';
+import type { PreparedChatRequest } from './request';
+
+interface ResponseStreamState {
+	accumulatedReasoning: string;
+	emittedToolCallIds: string[];
+}
+
+export interface StreamChatCompletionOptions {
+	prepared: PreparedChatRequest;
+	progress: vscode.Progress<vscode.LanguageModelResponsePart>;
+	token: vscode.CancellationToken;
+	reasoningCache: Map<string, ReasoningEntry>;
+	getCharsPerToken: () => number;
+	setCharsPerToken: (charsPerToken: number) => void;
+}
+
+export function streamChatCompletion({
+	prepared,
+	progress,
+	token,
+	reasoningCache,
+	getCharsPerToken,
+	setCharsPerToken,
+}: StreamChatCompletionOptions): Promise<void> {
+	const state: ResponseStreamState = {
+		accumulatedReasoning: '',
+		emittedToolCallIds: [],
+	};
+
+	return new Promise<void>((resolve, reject) => {
+		prepared.client.streamChatCompletion(
+			prepared.request,
+			{
+				onContent: (content: string) => {
+					progress.report(new vscode.LanguageModelTextPart(content));
+				},
+
+				onThinking: (text: string) => {
+					handleThinking(text, state, progress);
+				},
+
+				onToolCall: (toolCall: DeepSeekToolCall) => {
+					handleToolCall(toolCall, prepared.isThinkingModel, state, progress, reasoningCache);
+				},
+
+				onError: (error: Error) => {
+					reject(error);
+				},
+
+				onDone: () => {
+					finalizeReasoningCache(
+						prepared.isThinkingModel,
+						prepared.trailingToolResults,
+						state,
+						reasoningCache,
+						prepared.cacheDiagnostics,
+					);
+					resolve();
+				},
+
+				onUsage: (usage) => {
+					const charsPerToken = updateCharsPerToken(
+						prepared.totalRequestChars,
+						usage,
+						getCharsPerToken(),
+					);
+					setCharsPerToken(charsPerToken);
+					prepared.cacheDiagnostics.onUsage(usage, charsPerToken);
+				},
+			},
+			token,
+		);
+	});
+}
+
+function handleThinking(
+	text: string,
+	state: ResponseStreamState,
+	progress: vscode.Progress<vscode.LanguageModelResponsePart>,
+): void {
+	state.accumulatedReasoning += text;
+
+	// LanguageModelThinkingPart is a proposed API; the project root augmentation provides types.
+	progress.report(
+		new vscode.LanguageModelThinkingPart(text) as unknown as vscode.LanguageModelResponsePart,
+	);
+}
+
+function handleToolCall(
+	toolCall: DeepSeekToolCall,
+	isThinkingModel: boolean,
+	state: ResponseStreamState,
+	progress: vscode.Progress<vscode.LanguageModelResponsePart>,
+	reasoningCache: Map<string, ReasoningEntry>,
+): void {
+	state.emittedToolCallIds.push(toolCall.id);
+
+	if (isThinkingModel && state.accumulatedReasoning) {
+		reasoningCache.set(toolCall.id, {
+			text: state.accumulatedReasoning,
+			timestamp: Date.now(),
+		});
+	}
+
+	try {
+		const args = JSON.parse(toolCall.function.arguments);
+		progress.report(
+			new vscode.LanguageModelToolCallPart(toolCall.id, toolCall.function.name, args),
+		);
+	} catch {
+		progress.report(new vscode.LanguageModelToolCallPart(toolCall.id, toolCall.function.name, {}));
+	}
+}
+
+function finalizeReasoningCache(
+	isThinkingModel: boolean,
+	trailingToolResults: number,
+	state: ResponseStreamState,
+	reasoningCache: Map<string, ReasoningEntry>,
+	cacheDiagnostics: CacheDiagnosticsRun,
+): void {
+	if (isThinkingModel && state.accumulatedReasoning && state.emittedToolCallIds.length === 0) {
+		const responseMessageId = `resp_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`;
+		reasoningCache.set(responseMessageId, {
+			text: state.accumulatedReasoning,
+			timestamp: Date.now(),
+		});
+	}
+
+	const cacheSizeBeforePrune = reasoningCache.size;
+	pruneReasoningCache(reasoningCache, false);
+	const evictedReasoningEntries = Math.max(0, cacheSizeBeforePrune - reasoningCache.size);
+	cacheDiagnostics.onDone({
+		reasoningCacheSize: reasoningCache.size,
+		evictedReasoningEntries,
+		emittedToolCalls: state.emittedToolCallIds.length,
+		trailingToolResults,
+	});
+}
+
+function updateCharsPerToken(
+	totalRequestChars: number,
+	usage: DeepSeekUsage,
+	charsPerToken: number,
+): number {
+	if (totalRequestChars > 0 && usage.prompt_tokens > 0) {
+		const observedRatio = totalRequestChars / usage.prompt_tokens;
+		return charsPerToken * 0.7 + observedRatio * 0.3;
+	}
+	return charsPerToken;
+}

--- a/src/provider/tokens.ts
+++ b/src/provider/tokens.ts
@@ -1,0 +1,22 @@
+import vscode from 'vscode';
+
+export function estimateTokenCount(
+	text: string | vscode.LanguageModelChatRequestMessage,
+	charsPerToken: number,
+): number {
+	if (typeof text === 'string') {
+		return Math.max(1, Math.ceil(text.length / charsPerToken));
+	}
+
+	if (!text?.content || !Array.isArray(text.content)) {
+		return 1;
+	}
+
+	let total = 0;
+	for (const part of text.content) {
+		if (part instanceof vscode.LanguageModelTextPart) {
+			total += part.value.length;
+		}
+	}
+	return Math.max(1, Math.ceil(total / charsPerToken));
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,6 +30,14 @@ export interface DeepSeekTool {
 	};
 }
 
+export interface DeepSeekUsage {
+	prompt_tokens: number;
+	completion_tokens: number;
+	total_tokens: number;
+	prompt_cache_hit_tokens?: number;
+	prompt_cache_miss_tokens?: number;
+}
+
 export interface DeepSeekRequest {
 	model: string;
 	messages: DeepSeekMessage[];
@@ -69,13 +77,7 @@ export interface DeepSeekStreamChunk {
 		};
 		finish_reason: string | null;
 	}>;
-	usage?: {
-		prompt_tokens: number;
-		completion_tokens: number;
-		total_tokens: number;
-		prompt_cache_hit_tokens?: number;
-		prompt_cache_miss_tokens?: number;
-	};
+	usage?: DeepSeekUsage;
 }
 
 // ---- Stream callbacks ----
@@ -86,13 +88,7 @@ export interface StreamCallbacks {
 	onToolCall: (toolCall: DeepSeekToolCall) => void;
 	onError: (error: Error) => void;
 	onDone: () => void;
-	onUsage?: (usage: {
-		prompt_tokens: number;
-		completion_tokens: number;
-		total_tokens: number;
-		prompt_cache_hit_tokens?: number;
-		prompt_cache_miss_tokens?: number;
-	}) => void;
+	onUsage?: (usage: DeepSeekUsage) => void;
 }
 
 // ---- Model definitions ----


### PR DESCRIPTION
Adds opt-in, privacy-preserving cache trace diagnostics behind the generic `deepseek-copilot.debug` setting.

Summary:
- Add cache trace snapshots, prefix comparison, tool schema hashing, reasoning cache warnings, and vision history markers for troubleshooting cache behavior.
- Keep baseline token/cache usage logging enabled while gating detailed cache trace logs behind `deepseek-copilot.debug`.
- Refactor the chat provider into focused request, stream, model, and token helper modules without changing vision, conversion, or reasoning replay behavior.
- Document the new debug setting and add English/Chinese package i18n strings.

Validation:
- `npm run compile`
- `npm run format:check`
- `git diff --check`