### PR TITLE
Fix reasoning replay across tool turns

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -27,10 +27,12 @@ export class DeepSeekClient {
 		cancellationToken?: CancellationToken,
 	): Promise<void> {
 		const controller = new AbortController();
-
 		const cancelListener = cancellationToken?.onCancellationRequested(() => {
 			controller.abort();
 		});
+		if (cancellationToken?.isCancellationRequested) {
+			controller.abort();
+		}
 
 		try {
 			// Request usage stats in streaming responses so we can calibrate token counting.
@@ -75,7 +77,7 @@ export class DeepSeekClient {
 			while (true) {
 				if (cancellationToken?.isCancellationRequested) {
 					controller.abort();
-					break;
+					return;
 				}
 
 				const { done, value } = await reader.read();
@@ -172,8 +174,7 @@ export class DeepSeekClient {
 
 			callbacks.onDone();
 		} catch (error) {
-			if (error instanceof Error && error.name === 'AbortError') {
-				callbacks.onDone();
+			if (isAbortError(error) && cancellationToken?.isCancellationRequested) {
 				return;
 			}
 			callbacks.onError(error instanceof Error ? error : new Error(String(error)));
@@ -181,4 +182,8 @@ export class DeepSeekClient {
 			cancelListener?.dispose();
 		}
 	}
+}
+
+function isAbortError(error: unknown): boolean {
+	return error instanceof Error && error.name === 'AbortError';
 }

--- a/src/provider/cache.ts
+++ b/src/provider/cache.ts
@@ -5,15 +5,25 @@ import { MAX_CACHE_SIZE } from '../consts';
  * can inject reasoning_content back into prior assistant messages.
  *
  * Key strategy (per DeepSeek docs):
- *  - Non-tool-call turns: reasoning_content does NOT need to be passed back.
- *  - Tool-call turns: reasoning_content MUST be in ALL subsequent requests.
+ *  - Plain non-tool turns: reasoning_content does NOT need to be passed back.
+ *  - Tool-call turns and their post-tool final turns: reasoning_content MUST be
+ *    in ALL subsequent requests.
  *
- * We cache by tool_call IDs so we can look up which reasoning goes with which
- * tool-call-bearing assistant message when reconstructing the message history.
+ * We cache by stable history keys so we can look up which reasoning goes with
+ * tool-call-bearing assistant messages and final post-tool assistant messages
+ * when reconstructing the message history.
  */
 export interface ReasoningEntry {
 	text: string;
 	timestamp: number;
+}
+
+export function createToolReasoningKey(toolCallId: string): string {
+	return `tool:${toolCallId}`;
+}
+
+export function createPostToolReasoningKey(toolCallIds: readonly string[]): string {
+	return `post-tool:${toolCallIds.join(',')}`;
 }
 
 export function pruneReasoningCache(cache: Map<string, ReasoningEntry>, clearAll: boolean): void {

--- a/src/provider/cache.ts
+++ b/src/provider/cache.ts
@@ -23,7 +23,7 @@ export function createToolReasoningKey(toolCallId: string): string {
 }
 
 export function createPostToolReasoningKey(toolCallIds: readonly string[]): string {
-	return `post-tool:${toolCallIds.join(',')}`;
+	return `post-tool:${JSON.stringify(toolCallIds)}`;
 }
 
 export function pruneReasoningCache(cache: Map<string, ReasoningEntry>, clearAll: boolean): void {

--- a/src/provider/convert.ts
+++ b/src/provider/convert.ts
@@ -1,11 +1,11 @@
 import vscode from 'vscode';
 import type { DeepSeekMessage, DeepSeekTool, DeepSeekToolCall } from '../types';
-import type { ReasoningEntry } from './cache';
+import { createPostToolReasoningKey, createToolReasoningKey, type ReasoningEntry } from './cache';
 
 /**
  * Convert VS Code chat messages to DeepSeek format.
- * Injects cached reasoning_content for assistant messages that had tool calls
- * in prior turns.
+ * Injects cached reasoning_content for assistant tool-call messages and final
+ * assistant messages after tool results.
  */
 export function convertMessages(
 	messages: readonly vscode.LanguageModelChatRequestMessage[],
@@ -13,6 +13,7 @@ export function convertMessages(
 	reasoningCache: Map<string, ReasoningEntry>,
 ): DeepSeekMessage[] {
 	const result: DeepSeekMessage[] = [];
+	let recentToolResultIds: string[] = [];
 
 	for (const message of messages) {
 		const role = mapRole(message.role);
@@ -53,12 +54,19 @@ export function convertMessages(
 			let reasoningContent: string | undefined;
 			if (isThinkingModel && toolCalls.length > 0) {
 				for (const tc of toolCalls) {
-					const cached = reasoningCache.get(tc.id);
+					// Prefer new `tool:<callId>` key; fallback to bare `callId` for entries written
+					// before the stable-key change (read-only compat, no new bare-key writes).
+					const cached =
+						reasoningCache.get(createToolReasoningKey(tc.id)) ?? reasoningCache.get(tc.id);
 					if (cached) {
 						reasoningContent = cached.text;
 						break;
 					}
 				}
+			} else if (isThinkingModel && recentToolResultIds.length > 0) {
+				reasoningContent = reasoningCache.get(
+					createPostToolReasoningKey(recentToolResultIds),
+				)?.text;
 			}
 
 			if (content || toolCalls.length > 0) {
@@ -76,12 +84,18 @@ export function convertMessages(
 				}
 
 				result.push(msg);
+				recentToolResultIds = [];
 			}
-		} else if (content) {
-			result.push({
-				role: role as 'user' | 'assistant',
-				content: content,
-			});
+		} else {
+			if (content) {
+				recentToolResultIds = [];
+				result.push({
+					role: role as 'user' | 'assistant',
+					content: content,
+				});
+			} else if (toolResults.length === 0) {
+				recentToolResultIds = [];
+			}
 		}
 
 		// Tool result messages follow their associated assistant message
@@ -91,6 +105,7 @@ export function convertMessages(
 				content: tr.content,
 				tool_call_id: tr.callId,
 			});
+			recentToolResultIds.push(tr.callId);
 		}
 	}
 

--- a/src/provider/diagnostics.ts
+++ b/src/provider/diagnostics.ts
@@ -25,9 +25,17 @@ export interface CacheTraceStats {
 	emptyToolReasoningMessages: number;
 	missingToolReasoningMessages: number;
 	assistantAfterToolResultMessages: number;
+	assistantAfterToolResultToolCallMessages: number;
+	assistantAfterToolResultFinalMessages: number;
 	nonEmptyPostToolReasoningMessages: number;
 	emptyPostToolReasoningMessages: number;
 	missingPostToolReasoningMessages: number;
+	nonEmptyPostToolCallReasoningMessages: number;
+	emptyPostToolCallReasoningMessages: number;
+	missingPostToolCallReasoningMessages: number;
+	nonEmptyPostToolFinalReasoningMessages: number;
+	emptyPostToolFinalReasoningMessages: number;
+	missingPostToolFinalReasoningMessages: number;
 	imageDescriptionMessages: number;
 	imageDescriptionParts: number;
 	unableImageMessages: number;
@@ -59,7 +67,10 @@ export interface CacheTraceMessageSummary {
 	emptyReasoning: boolean;
 	missingToolReasoning: boolean;
 	followsToolResult: boolean;
+	afterToolResultKind: 'none' | 'tool-call' | 'final';
 	missingPostToolReasoning: boolean;
+	missingPostToolCallReasoning: boolean;
+	missingPostToolFinalReasoning: boolean;
 }
 
 export interface CacheTraceToolSummary {
@@ -119,7 +130,29 @@ export interface CacheDiagnosticsDoneInfo {
 
 export interface CacheDiagnosticsRun {
 	onDone(info: CacheDiagnosticsDoneInfo): void;
+	onCancellationTokenRequested(): void;
 	onUsage(usage: DeepSeekUsage, charsPerToken: number): void;
+}
+
+export function observeCancellationToken(
+	token: vscode.CancellationToken,
+	diagnosticsRun: CacheDiagnosticsRun,
+	onCancellationRequested?: () => void,
+): vscode.Disposable {
+	let notified = false;
+	const notifyCancellationRequested = (): void => {
+		if (notified) {
+			return;
+		}
+		notified = true;
+		diagnosticsRun.onCancellationTokenRequested();
+		onCancellationRequested?.();
+	};
+	const listener = token.onCancellationRequested(notifyCancellationRequested);
+	if (token.isCancellationRequested) {
+		notifyCancellationRequested();
+	}
+	return listener;
 }
 
 export interface CacheDiagnosticsRecorder {
@@ -266,6 +299,8 @@ class DefaultCacheDiagnosticsRecorder implements CacheDiagnosticsRecorder {
 }
 
 class ActiveCacheDiagnosticsRun implements CacheDiagnosticsRun {
+	private cancellationLogged = false;
+
 	constructor(
 		private readonly recorder: DefaultCacheDiagnosticsRecorder,
 		private readonly requestId: number,
@@ -296,10 +331,20 @@ class ActiveCacheDiagnosticsRun implements CacheDiagnosticsRun {
 			);
 		}
 	}
+
+	onCancellationTokenRequested(): void {
+		if (this.cancellationLogged) {
+			return;
+		}
+		this.cancellationLogged = true;
+		logger.info(`[cache-trace #${this.requestId}] cancellation token requested; aborting stream`);
+	}
 }
 
 class NoopCacheDiagnosticsRun implements CacheDiagnosticsRun {
 	onDone(_info: CacheDiagnosticsDoneInfo): void {}
+
+	onCancellationTokenRequested(): void {}
 
 	onUsage(usage: DeepSeekUsage, charsPerToken: number): void {
 		logUsage(usage, charsPerToken);
@@ -487,6 +532,11 @@ function formatVscodeMessageTrace(
 			let imageParts = 0;
 			let toolCallParts = 0;
 			let toolResultParts = 0;
+			let thinkingParts = 0;
+			let thinkingChars = 0;
+			const thinkingValueTypes = new Set<string>();
+			const thinkingHashes: string[] = [];
+			const unknownPartConstructors = new Map<string, number>();
 
 			for (const part of msg.content) {
 				if (part instanceof vscode.LanguageModelTextPart) {
@@ -500,6 +550,18 @@ function formatVscodeMessageTrace(
 					toolCallParts += 1;
 				} else if (part instanceof vscode.LanguageModelToolResultPart) {
 					toolResultParts += 1;
+				} else if (isLanguageModelThinkingPart(part)) {
+					const value = normalizeThinkingPartValue(part.value);
+					thinkingParts += 1;
+					thinkingChars += value.text.length;
+					thinkingValueTypes.add(value.type);
+					thinkingHashes.push(hashString(value.text));
+				} else {
+					const constructorName = getPartConstructorName(part);
+					unknownPartConstructors.set(
+						constructorName,
+						(unknownPartConstructors.get(constructorName) ?? 0) + 1,
+					);
 				}
 			}
 
@@ -513,12 +575,43 @@ function formatVscodeMessageTrace(
 			if (toolResultParts) {
 				parts.push(`toolResults=${toolResultParts}`);
 			}
+			if (thinkingParts) {
+				parts.push(
+					`thinking=${thinkingParts}:chars=${thinkingChars}:types=${[...thinkingValueTypes].join(
+						'+',
+					)}:hashes=${thinkingHashes.join(',')}`,
+				);
+			}
+			for (const [constructorName, count] of unknownPartConstructors) {
+				parts.push(`unknown=${constructorName}:${count}`);
+			}
 
 			const suffix = parts.length > 0 ? ` (${parts.join(',')})` : '';
 
 			return `${role}#${index}:chars=${textChars}${suffix}`;
 		})
 		.join(' | ');
+}
+
+function isLanguageModelThinkingPart(part: unknown): part is vscode.LanguageModelThinkingPart {
+	return (
+		typeof vscode.LanguageModelThinkingPart === 'function' &&
+		part instanceof vscode.LanguageModelThinkingPart
+	);
+}
+
+function normalizeThinkingPartValue(value: string | string[]): { text: string; type: string } {
+	if (Array.isArray(value)) {
+		return { text: value.join(''), type: 'string[]' };
+	}
+	return { text: value, type: 'string' };
+}
+
+function getPartConstructorName(part: unknown): string {
+	if (!part || typeof part !== 'object') {
+		return typeof part;
+	}
+	return part.constructor?.name ?? 'object';
 }
 
 export function createCacheTraceSnapshot(request: DeepSeekRequest): CacheTraceSnapshot {
@@ -622,7 +715,10 @@ export function formatCacheTraceSnapshot(snapshot: CacheTraceSnapshot): string {
 		` toolReasoning(nonEmpty=${stats.nonEmptyToolReasoningMessages},empty=${stats.emptyToolReasoningMessages},missing=${stats.missingToolReasoningMessages})` +
 		` missingToolReasoning=${stats.missingToolReasoningMessages}` +
 		` assistantAfterToolResult=${stats.assistantAfterToolResultMessages}` +
+		` afterToolResult(toolCall=${stats.assistantAfterToolResultToolCallMessages},final=${stats.assistantAfterToolResultFinalMessages})` +
 		` postToolReasoning(nonEmpty=${stats.nonEmptyPostToolReasoningMessages},empty=${stats.emptyPostToolReasoningMessages},missing=${stats.missingPostToolReasoningMessages})` +
+		` postToolCallReasoning(nonEmpty=${stats.nonEmptyPostToolCallReasoningMessages},empty=${stats.emptyPostToolCallReasoningMessages},missing=${stats.missingPostToolCallReasoningMessages})` +
+		` postToolFinalReasoning(nonEmpty=${stats.nonEmptyPostToolFinalReasoningMessages},empty=${stats.emptyPostToolFinalReasoningMessages},missing=${stats.missingPostToolFinalReasoningMessages})` +
 		` missingPostToolReasoning=${stats.missingPostToolReasoningMessages}` +
 		` imageDescriptions=${stats.imageDescriptionMessages}` +
 		` toolNames=${formatToolNames(snapshot.toolNames)}`
@@ -731,13 +827,18 @@ export function getCacheTraceWarnings(
 			`${snapshot.stats.missingToolReasoningMessages} assistant tool-call message(s) are missing cached reasoning_content; DeepSeek requires this in thinking tool-call histories and cache prefixes may drift.`,
 		);
 	}
-	if (snapshot.stats.missingPostToolReasoningMessages > 0) {
+	if (snapshot.stats.missingPostToolCallReasoningMessages > 0) {
 		warnings.push(
-			`${snapshot.stats.missingPostToolReasoningMessages} assistant message(s) after tool results are missing cached reasoning_content; DeepSeek requires final tool-call-turn reasoning in subsequent requests.`,
+			`${snapshot.stats.missingPostToolCallReasoningMessages} assistant tool-call message(s) after tool results are missing cached reasoning_content; these should replay via tool:<id> keys.`,
+		);
+	}
+	if (snapshot.stats.missingPostToolFinalReasoningMessages > 0) {
+		warnings.push(
+			`${snapshot.stats.missingPostToolFinalReasoningMessages} final assistant message(s) after tool results are missing cached reasoning_content; these should replay via post-tool:<ids> keys.`,
 		);
 	}
 	const emptyReasoningMessages =
-		snapshot.stats.emptyToolReasoningMessages + snapshot.stats.emptyPostToolReasoningMessages;
+		snapshot.stats.emptyToolReasoningMessages + snapshot.stats.emptyPostToolFinalReasoningMessages;
 	if (emptyReasoningMessages > 0) {
 		warnings.push(
 			`${emptyReasoningMessages} reasoning-required assistant message reference(s) have empty reasoning_content fallback; this is protocol-safe but may indicate the original reasoning cache was unavailable after extension restart/reload.`,
@@ -794,7 +895,7 @@ function summarizeMessages(messages: DeepSeekMessage[]): CacheTraceMessageSummar
 		summaries.push(summarizeMessage(message, index, followsToolResult));
 		if (message.role === 'tool') {
 			followsToolResult = true;
-		} else if (message.role === 'assistant') {
+		} else {
 			followsToolResult = false;
 		}
 	}
@@ -811,6 +912,11 @@ function summarizeMessage(
 	const reasoningChars = message.reasoning_content?.length ?? 0;
 	const toolCalls = message.tool_calls?.length ?? 0;
 	const assistantAfterToolResult = message.role === 'assistant' && followsToolResult;
+	const afterToolResultKind = assistantAfterToolResult
+		? toolCalls > 0
+			? ('tool-call' as const)
+			: ('final' as const)
+		: ('none' as const);
 	const hasReasoningContent = message.reasoning_content !== undefined;
 	const hasEmptyReasoningContent = hasReasoningContent && reasoningChars === 0;
 	const imageDescriptionCount = countLiteral(message.content, '[Image Description:');
@@ -839,7 +945,10 @@ function summarizeMessage(
 		emptyReasoning: hasEmptyReasoningContent,
 		missingToolReasoning: message.role === 'assistant' && toolCalls > 0 && !hasReasoningContent,
 		followsToolResult: assistantAfterToolResult,
+		afterToolResultKind,
 		missingPostToolReasoning: assistantAfterToolResult && !hasReasoningContent,
+		missingPostToolCallReasoning: afterToolResultKind === 'tool-call' && !hasReasoningContent,
+		missingPostToolFinalReasoning: afterToolResultKind === 'final' && !hasReasoningContent,
 	};
 }
 
@@ -867,9 +976,17 @@ function summarizeStats(messages: DeepSeekMessage[], toolCount: number): CacheTr
 	let emptyToolReasoningMessages = 0;
 	let missingToolReasoningMessages = 0;
 	let assistantAfterToolResultMessages = 0;
+	let assistantAfterToolResultToolCallMessages = 0;
+	let assistantAfterToolResultFinalMessages = 0;
 	let nonEmptyPostToolReasoningMessages = 0;
 	let emptyPostToolReasoningMessages = 0;
 	let missingPostToolReasoningMessages = 0;
+	let nonEmptyPostToolCallReasoningMessages = 0;
+	let emptyPostToolCallReasoningMessages = 0;
+	let missingPostToolCallReasoningMessages = 0;
+	let nonEmptyPostToolFinalReasoningMessages = 0;
+	let emptyPostToolFinalReasoningMessages = 0;
+	let missingPostToolFinalReasoningMessages = 0;
 	let imageDescriptionMessages = 0;
 	let imageDescriptionParts = 0;
 	let unableImageMessages = 0;
@@ -928,12 +1045,33 @@ function summarizeStats(messages: DeepSeekMessage[], toolCount: number): CacheTr
 		const messageReasoningChars = message.reasoning_content?.length ?? 0;
 		if (message.role === 'assistant' && followsToolResult) {
 			assistantAfterToolResultMessages += 1;
+			const isToolCallAfterToolResult = toolCalls > 0;
+			if (isToolCallAfterToolResult) {
+				assistantAfterToolResultToolCallMessages += 1;
+			} else {
+				assistantAfterToolResultFinalMessages += 1;
+			}
 			if (message.reasoning_content === undefined) {
 				missingPostToolReasoningMessages += 1;
+				if (isToolCallAfterToolResult) {
+					missingPostToolCallReasoningMessages += 1;
+				} else {
+					missingPostToolFinalReasoningMessages += 1;
+				}
 			} else if (messageReasoningChars === 0) {
 				emptyPostToolReasoningMessages += 1;
+				if (isToolCallAfterToolResult) {
+					emptyPostToolCallReasoningMessages += 1;
+				} else {
+					emptyPostToolFinalReasoningMessages += 1;
+				}
 			} else {
 				nonEmptyPostToolReasoningMessages += 1;
+				if (isToolCallAfterToolResult) {
+					nonEmptyPostToolCallReasoningMessages += 1;
+				} else {
+					nonEmptyPostToolFinalReasoningMessages += 1;
+				}
 			}
 		}
 
@@ -955,7 +1093,7 @@ function summarizeStats(messages: DeepSeekMessage[], toolCount: number): CacheTr
 
 		if (message.role === 'tool') {
 			followsToolResult = true;
-		} else if (message.role === 'assistant') {
+		} else {
 			followsToolResult = false;
 		}
 	}
@@ -976,9 +1114,17 @@ function summarizeStats(messages: DeepSeekMessage[], toolCount: number): CacheTr
 		emptyToolReasoningMessages,
 		missingToolReasoningMessages,
 		assistantAfterToolResultMessages,
+		assistantAfterToolResultToolCallMessages,
+		assistantAfterToolResultFinalMessages,
 		nonEmptyPostToolReasoningMessages,
 		emptyPostToolReasoningMessages,
 		missingPostToolReasoningMessages,
+		nonEmptyPostToolCallReasoningMessages,
+		emptyPostToolCallReasoningMessages,
+		missingPostToolCallReasoningMessages,
+		nonEmptyPostToolFinalReasoningMessages,
+		emptyPostToolFinalReasoningMessages,
+		missingPostToolFinalReasoningMessages,
 		imageDescriptionMessages,
 		imageDescriptionParts,
 		unableImageMessages,
@@ -1006,7 +1152,8 @@ function formatMessageSummary(summary: CacheTraceMessageSummary | undefined): st
 		` reasoning=${summary.reasoningChars}` +
 		` emptyReasoning=${summary.emptyReasoning}` +
 		` markers=${formatMarkerSummary(summary)}` +
-		` followsToolResult=${summary.followsToolResult}`
+		` followsToolResult=${summary.followsToolResult}` +
+		` afterToolResultKind=${summary.afterToolResultKind}`
 	);
 }
 

--- a/src/provider/request.ts
+++ b/src/provider/request.ts
@@ -4,7 +4,7 @@ import { DeepSeekClient } from '../client';
 import { getApiModelId, getBaseUrl, getMaxTokens } from '../config';
 import { MODELS } from '../consts';
 import { t } from '../i18n';
-import type { DeepSeekRequest } from '../types';
+import type { DeepSeekMessage, DeepSeekRequest } from '../types';
 import { pruneReasoningCache, type ReasoningEntry } from './cache';
 import { convertMessages, convertTools, countMessageChars } from './convert';
 import type { CacheDiagnosticsRecorder, CacheDiagnosticsRun } from './diagnostics';
@@ -16,7 +16,7 @@ export interface PreparedChatRequest {
 	request: DeepSeekRequest;
 	isThinkingModel: boolean;
 	totalRequestChars: number;
-	trailingToolResults: number;
+	trailingToolResultIds: string[];
 	cacheDiagnostics: CacheDiagnosticsRun;
 }
 
@@ -95,25 +95,21 @@ export async function prepareChatRequest({
 		request,
 		isThinkingModel,
 		totalRequestChars,
-		trailingToolResults: countTrailingToolResults(messages),
+		trailingToolResultIds: collectTrailingToolResultIds(deepseekMessages),
 		cacheDiagnostics: diagnosticsRun,
 	};
 }
 
-function countTrailingToolResults(
-	messages: readonly vscode.LanguageModelChatRequestMessage[],
-): number {
-	let trailingToolResults = 0;
+function collectTrailingToolResultIds(messages: readonly DeepSeekMessage[]): string[] {
+	const trailingToolResultIds: string[] = [];
 	for (let index = messages.length - 1; index >= 0; index -= 1) {
-		const toolResults = messages[index].content.filter(
-			(part) => part instanceof vscode.LanguageModelToolResultPart,
-		).length;
-		if (toolResults === 0) {
+		const message = messages[index];
+		if (message.role !== 'tool' || !message.tool_call_id) {
 			break;
 		}
-		trailingToolResults += toolResults;
+		trailingToolResultIds.push(message.tool_call_id);
 	}
-	return trailingToolResults;
+	return trailingToolResultIds.reverse();
 }
 
 function clearStaleReasoningCache(

--- a/src/provider/stream.ts
+++ b/src/provider/stream.ts
@@ -1,7 +1,12 @@
 import vscode from 'vscode';
 import type { DeepSeekToolCall, DeepSeekUsage } from '../types';
-import { pruneReasoningCache, type ReasoningEntry } from './cache';
-import type { CacheDiagnosticsRun } from './diagnostics';
+import {
+	createPostToolReasoningKey,
+	createToolReasoningKey,
+	pruneReasoningCache,
+	type ReasoningEntry,
+} from './cache';
+import { observeCancellationToken, type CacheDiagnosticsRun } from './diagnostics';
 import type { PreparedChatRequest } from './request';
 
 interface ResponseStreamState {
@@ -30,9 +35,12 @@ export function streamChatCompletion({
 		accumulatedReasoning: '',
 		emittedToolCallIds: [],
 	};
+	const cancelListener = observeCancellationToken(token, prepared.cacheDiagnostics, () => {
+		cacheEmittedToolCallReasoningOnCancellation(prepared.isThinkingModel, state, reasoningCache);
+	});
 
-	return new Promise<void>((resolve, reject) => {
-		prepared.client.streamChatCompletion(
+	return prepared.client
+		.streamChatCompletion(
 			prepared.request,
 			{
 				onContent: (content: string) => {
@@ -44,22 +52,21 @@ export function streamChatCompletion({
 				},
 
 				onToolCall: (toolCall: DeepSeekToolCall) => {
-					handleToolCall(toolCall, prepared.isThinkingModel, state, progress, reasoningCache);
+					handleToolCall(toolCall, state, progress);
 				},
 
 				onError: (error: Error) => {
-					reject(error);
+					throw error;
 				},
 
 				onDone: () => {
 					finalizeReasoningCache(
 						prepared.isThinkingModel,
-						prepared.trailingToolResults,
+						prepared.trailingToolResultIds,
 						state,
 						reasoningCache,
 						prepared.cacheDiagnostics,
 					);
-					resolve();
 				},
 
 				onUsage: (usage) => {
@@ -73,8 +80,10 @@ export function streamChatCompletion({
 				},
 			},
 			token,
-		);
-	});
+		)
+		.finally(() => {
+			cancelListener.dispose();
+		});
 }
 
 function handleThinking(
@@ -92,19 +101,10 @@ function handleThinking(
 
 function handleToolCall(
 	toolCall: DeepSeekToolCall,
-	isThinkingModel: boolean,
 	state: ResponseStreamState,
 	progress: vscode.Progress<vscode.LanguageModelResponsePart>,
-	reasoningCache: Map<string, ReasoningEntry>,
 ): void {
 	state.emittedToolCallIds.push(toolCall.id);
-
-	if (isThinkingModel && state.accumulatedReasoning) {
-		reasoningCache.set(toolCall.id, {
-			text: state.accumulatedReasoning,
-			timestamp: Date.now(),
-		});
-	}
 
 	try {
 		const args = JSON.parse(toolCall.function.arguments);
@@ -118,17 +118,23 @@ function handleToolCall(
 
 function finalizeReasoningCache(
 	isThinkingModel: boolean,
-	trailingToolResults: number,
+	trailingToolResultIds: readonly string[],
 	state: ResponseStreamState,
 	reasoningCache: Map<string, ReasoningEntry>,
 	cacheDiagnostics: CacheDiagnosticsRun,
 ): void {
-	if (isThinkingModel && state.accumulatedReasoning && state.emittedToolCallIds.length === 0) {
-		const responseMessageId = `resp_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`;
-		reasoningCache.set(responseMessageId, {
+	if (isThinkingModel && state.accumulatedReasoning) {
+		const entry: ReasoningEntry = {
 			text: state.accumulatedReasoning,
 			timestamp: Date.now(),
-		});
+		};
+		if (state.emittedToolCallIds.length > 0) {
+			for (const toolCallId of state.emittedToolCallIds) {
+				reasoningCache.set(createToolReasoningKey(toolCallId), entry);
+			}
+		} else if (trailingToolResultIds.length > 0) {
+			reasoningCache.set(createPostToolReasoningKey(trailingToolResultIds), entry);
+		}
 	}
 
 	const cacheSizeBeforePrune = reasoningCache.size;
@@ -138,8 +144,27 @@ function finalizeReasoningCache(
 		reasoningCacheSize: reasoningCache.size,
 		evictedReasoningEntries,
 		emittedToolCalls: state.emittedToolCallIds.length,
-		trailingToolResults,
+		trailingToolResults: trailingToolResultIds.length,
 	});
+}
+
+function cacheEmittedToolCallReasoningOnCancellation(
+	isThinkingModel: boolean,
+	state: ResponseStreamState,
+	reasoningCache: Map<string, ReasoningEntry>,
+): void {
+	if (!isThinkingModel || !state.accumulatedReasoning || state.emittedToolCallIds.length === 0) {
+		return;
+	}
+
+	const entry: ReasoningEntry = {
+		text: state.accumulatedReasoning,
+		timestamp: Date.now(),
+	};
+	for (const toolCallId of state.emittedToolCallIds) {
+		reasoningCache.set(createToolReasoningKey(toolCallId), entry);
+	}
+	pruneReasoningCache(reasoningCache, false);
 }
 
 function updateCharsPerToken(


### PR DESCRIPTION
## Summary
- Add stable reasoning cache keys for assistant tool-call turns and post-tool final turns.
- Replay cached `reasoning_content` for tool-call histories, including tool-result follow-up chains.
- Restore cancellation transport abort behavior while avoiding normal completion/final cache writes on cancellation.
- Expand cache-trace diagnostics for VS Code thinking parts, post-tool reasoning categories, rollback/truncation signals, and cancellation logging.

## Validation
- `npm run compile`
- `npm run lint`
- `npm run format:check`
- `git diff --check`
- Manual cache-trace validation with tool calls, denied permissions, rollback/retry, and network interruption scenarios.