### PR TITLE
Fix 400 errors from lone surrogate JSON payloads

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1,4 +1,5 @@
 import type { CancellationToken } from 'vscode';
+import { safeStringify } from './json';
 import { logger } from './logger';
 import type {
 	DeepSeekRequest,
@@ -47,7 +48,7 @@ export class DeepSeekClient {
 					'Content-Type': 'application/json',
 					Authorization: `Bearer ${this.apiKey}`,
 				},
-				body: JSON.stringify(requestBody),
+				body: safeStringify(requestBody),
 				signal: controller.signal,
 			});
 

--- a/src/json.ts
+++ b/src/json.ts
@@ -14,7 +14,7 @@ export function safeStringify(value: unknown): string {
 	});
 
 	if (json === undefined) {
-		throw new TypeError('Value cannot be serialized as a JSON request body');
+		throw new TypeError('Value cannot be serialized as JSON');
 	}
 
 	return json;

--- a/src/json.ts
+++ b/src/json.ts
@@ -1,0 +1,32 @@
+const REPLACEMENT_CHARACTER = '\uFFFD';
+const LONE_SURROGATE_PATTERN = /([\uD800-\uDBFF][\uDC00-\uDFFF])|[\uD800-\uDFFF]/g;
+
+type WellFormedString = string & {
+	toWellFormed?: () => string;
+};
+
+export function safeStringify(value: unknown): string {
+	const json = JSON.stringify(value, (_key, entryValue: unknown) => {
+		if (typeof entryValue === 'string') {
+			return toWellFormedString(entryValue);
+		}
+		return entryValue;
+	});
+
+	if (json === undefined) {
+		throw new TypeError('Value cannot be serialized as a JSON request body');
+	}
+
+	return json;
+}
+
+export function toWellFormedString(value: string): string {
+	const toWellFormed = (value as WellFormedString).toWellFormed;
+	if (typeof toWellFormed === 'function') {
+		return toWellFormed.call(value);
+	}
+
+	return value.replace(LONE_SURROGATE_PATTERN, (_match, pair: string | undefined) =>
+		pair ? pair : REPLACEMENT_CHARACTER,
+	);
+}

--- a/src/provider/convert.ts
+++ b/src/provider/convert.ts
@@ -1,4 +1,5 @@
 import vscode from 'vscode';
+import { safeStringify } from '../json';
 import type { DeepSeekMessage, DeepSeekTool, DeepSeekToolCall } from '../types';
 import { createPostToolReasoningKey, createToolReasoningKey, type ReasoningEntry } from './cache';
 
@@ -31,7 +32,7 @@ export function convertMessages(
 					type: 'function',
 					function: {
 						name: part.name,
-						arguments: JSON.stringify(part.input),
+						arguments: safeStringify(part.input),
 					},
 				});
 			} else if (part instanceof vscode.LanguageModelToolResultPart) {
@@ -43,7 +44,7 @@ export function convertMessages(
 				}
 				toolResults.push({
 					callId: part.callId,
-					content: toolContent || JSON.stringify(part.content),
+					content: toolContent || safeStringify(part.content),
 				});
 			}
 		}


### PR DESCRIPTION
Fixes #38

## Summary
- Add `safeStringify` to normalize string values to well-formed Unicode before JSON serialization.
- Use it for DeepSeek request bodies and nested tool-call/result JSON strings.
- Preserve valid surrogate pairs while replacing lone surrogate code units with U+FFFD.

## Verification
- `npm run format:check`
- `npm run compile`
- `npm run lint`
- `npm test` is not available in this package (`Missing script: "test"`).