### PR TITLE
Fix Marketplace display metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "deepseek-v4-for-copilot",
-  "displayName": "%deepseek-copilot.displayName%",
-  "description": "%deepseek-copilot.description%",
+  "displayName": "DeepSeek V4 for Copilot Chat",
+  "description": "Pick DeepSeek V4 Pro & Flash from the Copilot Chat model picker. Vision, thinking mode, agent tools — zero config, BYOK.",
   "icon": "resources/icon.png",
   "version": "0.4.0",
   "publisher": "Vizards",
@@ -49,7 +49,7 @@
     "languageModelChatProviders": [
       {
         "vendor": "deepseek",
-        "displayName": "%deepseek-copilot.providerDisplayName%"
+        "displayName": "DeepSeek"
       }
     ],
     "commands": [

--- a/package.nls.json
+++ b/package.nls.json
@@ -1,7 +1,4 @@
 {
-  "deepseek-copilot.displayName": "DeepSeek V4 for Copilot Chat",
-  "deepseek-copilot.description": "Pick DeepSeek V4 Pro & Flash from the Copilot Chat model picker. Vision, thinking mode, agent tools — zero config, BYOK.",
-  "deepseek-copilot.providerDisplayName": "DeepSeek",
   "deepseek-copilot.command.setApiKey": "DeepSeek: Set API Key",
   "deepseek-copilot.command.getApiKey": "DeepSeek: Get API Key",
   "deepseek-copilot.command.clearApiKey": "DeepSeek: Clear API Key",

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -1,7 +1,4 @@
 {
-  "deepseek-copilot.displayName": "DeepSeek V4 for Copilot Chat",
-  "deepseek-copilot.description": "在 Copilot Chat 模型选择器中使用 DeepSeek V4 Pro & Flash。支持视觉识别、思考模式、智能体工具。需自行提供 API Key。",
-  "deepseek-copilot.providerDisplayName": "DeepSeek",
   "deepseek-copilot.command.setApiKey": "DeepSeek: 设置 API Key",
   "deepseek-copilot.command.getApiKey": "DeepSeek: 获取 API Key",
   "deepseek-copilot.command.clearApiKey": "DeepSeek: 清除 API Key",


### PR DESCRIPTION
## Summary
- replace top-level Marketplace `displayName` and `description` placeholders with literal manifest metadata
- inline the provider display name and remove now-unused NLS entries
- leave package version unchanged for the version bot

## Validation
- `npm run compile`