### PR TITLE
fix: remove extensionDependencies on github.copilot-chat for SSH-Remote compatibility (#37)

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,9 +14,6 @@
     "vscode": "^1.116.0",
     "node": ">=24"
   },
-  "extensionDependencies": [
-    "github.copilot-chat"
-  ],
   "extensionKind": [
     "workspace"
   ],


### PR DESCRIPTION
Copilot Chat is now built-in to VS Code, but in SSH-Remote environments the built-in extension is not explicitly registered, causing the hard extensionDependencies declaration to fail at extension activation.

Remove the extensionDependencies field from package.json and update the comment in extension.ts to explain why. Since Copilot Chat ships as a built-in extension, its activation order is naturally guaranteed without an explicit dependency declaration.