### PR TITLE
ci: generate marketplace README for VSIX packages

### DIFF
--- a/.github/scripts/prepare-marketplace-readme.sh
+++ b/.github/scripts/prepare-marketplace-readme.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source_path="${1:-README.md}"
+output_path="${2:-dist/README.marketplace.md}"
+
+mkdir -p "$(dirname "$output_path")"
+
+awk '
+  /<!-- marketplace-readme:remove-start -->/ {
+    if (removing) {
+      print "Nested marketplace-readme remove block." > "/dev/stderr"
+      exit 1
+    }
+    removing = 1
+    removed += 1
+    next
+  }
+
+  /<!-- marketplace-readme:remove-end -->/ {
+    if (!removing) {
+      print "Unexpected marketplace-readme remove end marker." > "/dev/stderr"
+      exit 1
+    }
+    removing = 0
+    next
+  }
+
+  !removing {
+    print
+  }
+
+  END {
+    if (removing) {
+      print "Unclosed marketplace-readme remove block." > "/dev/stderr"
+      exit 1
+    }
+    if (removed != 1) {
+      printf "Expected 1 marketplace-readme remove block, found %d.\n", removed > "/dev/stderr"
+      exit 1
+    }
+  }
+' "$source_path" > "$output_path"

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,4 +1,5 @@
 .vscode/**
+README.md
 src/**
 out/**/*.map
 out/**/*.d.ts
@@ -18,4 +19,3 @@ package-lock.json
 .env*
 !.env.example
 vscode.proposed.languageModelThinkingPart.d.ts
-

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 <h1 align="center">DeepSeek V4 for Copilot Chat</h1>
 
 <p align="center">
+  <!-- marketplace-readme:remove-start -->
   <a href="https://marketplace.visualstudio.com/items?itemName=Vizards.deepseek-v4-for-copilot"><img src="https://img.shields.io/badge/VS%20Code%20Marketplace-Install-007ACC?logo=visualstudiocode&logoColor=white&style=for-the-badge" alt="Install from VS Code Marketplace"></a>
   <a href="https://open-vsx.org/extension/Vizards/deepseek-v4-for-copilot"><img src="https://img.shields.io/badge/Open%20VSX-Install-6A4FB6?style=for-the-badge" alt="Install from Open VSX"></a>
   <br/>
+  <!-- marketplace-readme:remove-end -->
   <img src="https://img.shields.io/github/v/release/Vizards/deepseek-v4-for-copilot?style=for-the-badge&label=Version" alt="Version" />
   <img src="https://vsmarketplacebadges.dev/installs-short/Vizards.deepseek-v4-for-copilot.svg?style=for-the-badge" alt="Installs" />
 </p>
@@ -67,10 +69,10 @@ Pure VS Code API + Node.js built-ins. No Python, no Docker, no local proxy serve
 
 ### Installation
 
-Choose the install path that matches your editor:
+Install from the registry used by your editor:
 
-1. **VS Code Marketplace** — install from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=Vizards.deepseek-v4-for-copilot).
-2. **Open VSX** — install from [Open VSX](https://open-vsx.org/extension/Vizards/deepseek-v4-for-copilot). If your VS Code build does not use Open VSX, follow the [Open VSX in VS Code guide](https://github.com/eclipse-openvsx/openvsx/wiki/Using-Open-VSX-in-VS-Code) to configure the registry.
+1. **Microsoft VS Code** — install from [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=Vizards.deepseek-v4-for-copilot).
+2. **Editors that use Open VSX** — install from [Open VSX](https://open-vsx.org/extension/Vizards/deepseek-v4-for-copilot).
 
 ### Usage
 

--- a/package.json
+++ b/package.json
@@ -157,14 +157,13 @@
   },
   "scripts": {
     "clean": "node -e \"require('node:fs').rmSync('out', { recursive: true, force: true, maxRetries: process.platform === 'win32' ? 10 : 0 })\"",
-    "vscode:prepublish": "npm run compile",
+    "vscode:prepublish": "bash .github/scripts/prepare-marketplace-readme.sh && npm run compile",
     "compile": "npm run clean && tsc -p ./",
     "watch": "npm run clean && tsc -watch -p ./",
     "lint": "oxlint",
     "format": "oxfmt --write src/",
     "format:check": "oxfmt --check src/",
-    "package": "vsce package -o dist/",
-    "publish": "vsce publish",
+    "package": "vsce package --readme-path dist/README.marketplace.md -o dist/",
     "login": "vsce login Vizards"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- keep the GitHub README with both registry install badges
- mark the top install CTA badge block so packaged README generation can remove it without matching badge alt text
- generate a marketplace-specific README during `vscode:prepublish` with `.github/scripts/prepare-marketplace-readme.sh`
- package VSIX files with the generated README via `vsce package --readme-path`; release/rescue workflows publish that prebuilt VSIX to VS Code Marketplace and Open VSX

## Verification
- `npm run package`
- `rm -rf dist && mkdir -p dist && npm run package`
- `npm run lint`
- `npm run format:check`
- `git diff --check`
- inspected `extension/readme.md` inside the generated VSIX