### PR TITLE
fix: fix the wrong max-input-tokens size

### DIFF
--- a/src/consts.ts
+++ b/src/consts.ts
@@ -67,13 +67,13 @@ export const MAX_CACHE_SIZE = 200;
  */
 
 const K_UNIT = 1024;
-const CONTEXT_SIZE_K = 1000;
-const CONTEXT_MAX_OUT_TOKEN_K = 384;
-const CONTEXT_MAX_IN_TOKEN_K = CONTEXT_SIZE_K - CONTEXT_MAX_OUT_TOKEN_K;
+const CONTEXT_LEN_K = 1000;
+const MAX_OUTPUT_K = 384;
+const MAX_INPUT_K = CONTEXT_LEN_K - MAX_OUTPUT_K;
 
-// export const MODEL_CONTEXT_SIZE = CONTEXT_SIZE_K * K_UNIT;
-export const MODEL_MAX_INPUT_TOKEN = CONTEXT_MAX_IN_TOKEN_K * K_UNIT;
-export const MODEL_MAX_OUTPUT_TOKEN = CONTEXT_MAX_OUT_TOKEN_K * K_UNIT;
+export const MODEL_CONTEXT_LEN = CONTEXT_LEN_K * K_UNIT;
+export const MODEL_MAX_INPUT_TOKENS = MAX_INPUT_K * K_UNIT;
+export const MODEL_MAX_OUTPUT_TOKENS = MAX_OUTPUT_K * K_UNIT;
 
 /** Available DeepSeek models exposed through the language model provider. */
 export const MODELS: ModelDefinition[] = [
@@ -83,8 +83,8 @@ export const MODELS: ModelDefinition[] = [
 		family: 'deepseek',
 		version: 'v4',
 		detail: 'Fast, general-purpose model',
-		maxInputTokens: MODEL_MAX_INPUT_TOKEN,
-		maxOutputTokens: MODEL_MAX_OUTPUT_TOKEN,
+		maxInputTokens: MODEL_MAX_INPUT_TOKENS,
+		maxOutputTokens: MODEL_MAX_OUTPUT_TOKENS,
 		capabilities: {
 			toolCalling: true,
 			imageInput: true,
@@ -98,8 +98,8 @@ export const MODELS: ModelDefinition[] = [
 		family: 'deepseek',
 		version: 'v4',
 		detail: 'Most capable reasoning model',
-		maxInputTokens: MODEL_MAX_INPUT_TOKEN,
-		maxOutputTokens: MODEL_MAX_OUTPUT_TOKEN,
+		maxInputTokens: MODEL_MAX_INPUT_TOKENS,
+		maxOutputTokens: MODEL_MAX_OUTPUT_TOKENS,
 		capabilities: {
 			toolCalling: true,
 			imageInput: true,

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -61,6 +61,20 @@ export const MAX_CACHE_SIZE = 200;
 
 // ---- Model registry ----
 
+/**
+ * Context window sizing: total = 1000K, output = 384K, input = remainder.
+ * MODIFY these constants to recalculate maxInputTokens / maxOutputTokens.
+ */
+
+const K_UNIT = 1024;
+const CONTEXT_SIZE_K = 1000;
+const CONTEXT_MAX_OUT_TOKEN_K = 384;
+const CONTEXT_MAX_IN_TOKEN_K = CONTEXT_SIZE_K - CONTEXT_MAX_OUT_TOKEN_K;
+
+// export const MODEL_CONTEXT_SIZE = CONTEXT_SIZE_K * K_UNIT;
+export const MODEL_MAX_INPUT_TOKEN = CONTEXT_MAX_IN_TOKEN_K * K_UNIT;
+export const MODEL_MAX_OUTPUT_TOKEN = CONTEXT_MAX_OUT_TOKEN_K * K_UNIT;
+
 /** Available DeepSeek models exposed through the language model provider. */
 export const MODELS: ModelDefinition[] = [
 	{
@@ -69,8 +83,8 @@ export const MODELS: ModelDefinition[] = [
 		family: 'deepseek',
 		version: 'v4',
 		detail: 'Fast, general-purpose model',
-		maxInputTokens: 1048576,
-		maxOutputTokens: 393216,
+		maxInputTokens: MODEL_MAX_INPUT_TOKEN,
+		maxOutputTokens: MODEL_MAX_OUTPUT_TOKEN,
 		capabilities: {
 			toolCalling: true,
 			imageInput: true,
@@ -84,8 +98,8 @@ export const MODELS: ModelDefinition[] = [
 		family: 'deepseek',
 		version: 'v4',
 		detail: 'Most capable reasoning model',
-		maxInputTokens: 1048576,
-		maxOutputTokens: 393216,
+		maxInputTokens: MODEL_MAX_INPUT_TOKEN,
+		maxOutputTokens: MODEL_MAX_OUTPUT_TOKEN,
 		capabilities: {
 			toolCalling: true,
 			imageInput: true,


### PR DESCRIPTION
Fix the wrong `maxInputTokens` size.

According to the [official docs of API](https://api-docs.deepseek.com/api/create-chat-completion#:~:text=to%20max.-,max_tokens,-integer) and [context size instructions](https://api-docs.deepseek.com/quick_start/pricing#:~:text=how%20to%20switch-,CONTEXT%20LENGTH,-1M), the actual `maxInputToken` size should be `CONTEXT LENGTH - MAX OUTPUT = MAX INPUT`

The K-Unit can be verified by API response with `{"error":{"message":"Invalid max_tokens value, the valid range of max_tokens is [1, 393216]","type":"invalid_request_error","param":null,"code":"invalid_request_error"}}`

---

The way to fix this:
- add the local CONST to easily adjust the `CONTEXT_LEN_K` and `MAX_OUTPUT_K`
- auto calculate the actually context size, max input token and max output token