### PR TITLE
Persist DeepSeek reasoning cache per segment

### DIFF
--- a/src/consts.ts
+++ b/src/consts.ts
@@ -54,10 +54,13 @@ export const IMAGE_DESCRIPTION_UNAVAILABLE = '[Image Description unavailable]';
 export const IMAGE_DESCRIPTION_PREFIX = '[Image Description: ';
 export const IMAGE_DESCRIPTION_SUFFIX = ']';
 
-// ---- Cache ----
+// ---- Reasoning cache ----
 
-/** Max entries in the reasoning-content cache before eviction kicks in. */
-export const MAX_CACHE_SIZE = 200;
+/** Directory name under globalStorageUri for persisted DeepSeek reasoning_content. */
+export const REASONING_CACHE_DIR_NAME = 'reasoning-cache-v1';
+
+/** Keep persisted reasoning long enough to roughly match DeepSeek context cache lifetime. */
+export const REASONING_CACHE_TTL_MS = 72 * 60 * 60 * 1000;
 
 // ---- Model registry ----
 

--- a/src/provider/cache.ts
+++ b/src/provider/cache.ts
@@ -31,6 +31,7 @@ interface SegmentCacheState {
 	saveInFlight: Promise<void> | undefined;
 	dirty: boolean;
 	lastAccessedAt: number;
+	activeReferences: number;
 }
 
 interface ReasoningCacheCleanupResult {
@@ -53,7 +54,9 @@ export interface ReasoningRecorder {
 	prune(now?: number): ReasoningCachePruneResult;
 }
 
-export type SegmentReasoningCache = ReasoningLookup & ReasoningRecorder;
+export interface SegmentReasoningCache extends ReasoningLookup, ReasoningRecorder {
+	release(): Promise<void>;
+}
 
 export interface ReasoningCachePruneResult {
 	removed: number;
@@ -94,10 +97,12 @@ export class ReasoningCacheStore {
 	async forSegment(segmentId: string): Promise<SegmentReasoningCache> {
 		await this.cleanupPromise;
 		const state = this.getOrCreateSegmentState(segmentId);
+		state.activeReferences += 1;
 		await state.readyPromise;
 		this.markAccessed(state);
 
 		const getSize = () => state.cache.size;
+		let released = false;
 		return {
 			get size(): number {
 				return getSize();
@@ -118,6 +123,13 @@ export class ReasoningCacheStore {
 				void this.queueExpiredSegmentCleanup('record');
 			},
 			prune: (now) => this.pruneSegment(state, now),
+			release: async () => {
+				if (released) {
+					return;
+				}
+				released = true;
+				await this.releaseSegmentState(state);
+			},
 		};
 	}
 
@@ -149,6 +161,12 @@ export class ReasoningCacheStore {
 
 	private markAccessed(state: SegmentCacheState, now = Date.now()): void {
 		state.lastAccessedAt = now;
+	}
+
+	private async releaseSegmentState(state: SegmentCacheState): Promise<void> {
+		state.activeReferences = Math.max(0, state.activeReferences - 1);
+		this.markAccessed(state);
+		await this.unloadEmptySegment(state, false);
 	}
 
 	private pruneSegment(state: SegmentCacheState, now = Date.now()): ReasoningCachePruneResult {
@@ -184,6 +202,7 @@ export class ReasoningCacheStore {
 			saveInFlight: undefined,
 			dirty: false,
 			lastAccessedAt: Date.now(),
+			activeReferences: 0,
 		};
 		state.readyPromise = this.loadSegment(state);
 		this.segments.set(segmentId, state);
@@ -310,26 +329,17 @@ export class ReasoningCacheStore {
 		}
 
 		const now = Date.now();
-		const result: ReasoningCacheCleanupResult = {
-			scanned: 0,
-			deleted: 0,
-			errors: 0,
-		};
-		await Promise.all(
-			entries.map(async ([name, type]) => {
+		const fileResults = await Promise.all(
+			entries.map(async ([name, type]): Promise<ReasoningCacheCleanupResult> => {
 				if (type !== vscode.FileType.File || !name.endsWith('.json')) {
-					return;
+					return emptyCleanupResult();
 				}
 
-				result.scanned += 1;
 				const segmentId = name.slice(0, -'.json'.length);
 				const loadedState = this.segments.get(segmentId);
 				if (loadedState) {
 					const deleted = await this.pruneLoadedSegmentFile(loadedState, now);
-					if (deleted) {
-						result.deleted += 1;
-					}
-					return;
+					return { scanned: 1, deleted: deleted ? 1 : 0, errors: 0 };
 				}
 
 				const uri = vscode.Uri.joinPath(this.cacheRootUri, name);
@@ -337,16 +347,18 @@ export class ReasoningCacheStore {
 					const stat = await vscode.workspace.fs.stat(uri);
 					if (now - stat.mtime > REASONING_CACHE_TTL_MS) {
 						await vscode.workspace.fs.delete(uri);
-						result.deleted += 1;
+						return { scanned: 1, deleted: 1, errors: 0 };
 					}
 				} catch (error) {
 					if (!isFileNotFoundError(error)) {
-						result.errors += 1;
 						logger.warn(`Failed to prune reasoning cache file name=${name}`, error);
+						return { scanned: 1, deleted: 0, errors: 1 };
 					}
 				}
+				return { scanned: 1, deleted: 0, errors: 0 };
 			}),
 		);
+		const result = fileResults.reduce(addCleanupResults, emptyCleanupResult());
 		await this.unloadInactiveEmptySegments(now);
 
 		if (shouldLogCleanupResult(trigger, result)) {
@@ -378,7 +390,17 @@ export class ReasoningCacheStore {
 		now: number,
 		deletePersistedFile: boolean,
 	): Promise<boolean> {
-		if (state.cache.size > 0 || now - state.lastAccessedAt <= REASONING_CACHE_TTL_MS) {
+		if (now - state.lastAccessedAt <= REASONING_CACHE_TTL_MS) {
+			return false;
+		}
+		return this.unloadEmptySegment(state, deletePersistedFile);
+	}
+
+	private async unloadEmptySegment(
+		state: SegmentCacheState,
+		deletePersistedFile: boolean,
+	): Promise<boolean> {
+		if (state.activeReferences > 0 || state.cache.size > 0) {
 			return false;
 		}
 
@@ -389,7 +411,7 @@ export class ReasoningCacheStore {
 			await this.flushSegment(state);
 		}
 
-		if (state.cache.size === 0 && !state.dirty) {
+		if (state.activeReferences === 0 && state.cache.size === 0 && !state.dirty) {
 			this.segments.delete(state.segmentId);
 			return deletePersistedFile;
 		}
@@ -403,6 +425,21 @@ function shouldLogCleanupResult(
 	result: ReasoningCacheCleanupResult,
 ): boolean {
 	return trigger === 'startup' || result.deleted > 0 || result.errors > 0;
+}
+
+function emptyCleanupResult(): ReasoningCacheCleanupResult {
+	return { scanned: 0, deleted: 0, errors: 0 };
+}
+
+function addCleanupResults(
+	total: ReasoningCacheCleanupResult,
+	current: ReasoningCacheCleanupResult,
+): ReasoningCacheCleanupResult {
+	return {
+		scanned: total.scanned + current.scanned,
+		deleted: total.deleted + current.deleted,
+		errors: total.errors + current.errors,
+	};
 }
 
 export function pruneReasoningCache(

--- a/src/provider/cache.ts
+++ b/src/provider/cache.ts
@@ -60,6 +60,7 @@ export interface ReasoningCachePruneResult {
 }
 
 const REASONING_CACHE_SAVE_DEBOUNCE_MS = 500;
+const REASONING_CACHE_TOUCH_INTERVAL_MS = REASONING_CACHE_TTL_MS / 2;
 const textEncoder = new TextEncoder();
 const textDecoder = new TextDecoder();
 
@@ -124,8 +125,11 @@ export class ReasoningCacheStore {
 			return undefined;
 		}
 
-		entry.updatedAt = Date.now();
-		this.scheduleSave(state);
+		const now = Date.now();
+		if (now - entry.updatedAt >= REASONING_CACHE_TOUCH_INTERVAL_MS) {
+			entry.updatedAt = now;
+			this.scheduleSave(state);
+		}
 		return entry;
 	}
 

--- a/src/provider/cache.ts
+++ b/src/provider/cache.ts
@@ -1,4 +1,6 @@
-import { MAX_CACHE_SIZE } from '../consts';
+import vscode from 'vscode';
+import { REASONING_CACHE_DIR_NAME, REASONING_CACHE_TTL_MS } from '../consts';
+import { logger } from '../logger';
 
 /**
  * Reasoning cache: persists across turns so multi-turn tool-call conversations
@@ -13,33 +15,370 @@ import { MAX_CACHE_SIZE } from '../consts';
  * tool-call-bearing assistant messages and final post-tool assistant messages
  * when reconstructing the message history.
  */
-export interface ReasoningEntry {
+interface ReasoningEntry {
 	text: string;
-	timestamp: number;
+	updatedAt: number;
 }
 
-export function createToolReasoningKey(toolCallId: string): string {
+type PersistentReasoningSnapshot = Array<[reasoningKey: string, text: string, updatedAt: number]>;
+
+interface SegmentCacheState {
+	segmentId: string;
+	cacheUri: vscode.Uri;
+	cache: Map<string, ReasoningEntry>;
+	readyPromise: Promise<void>;
+	saveTimer: NodeJS.Timeout | undefined;
+	saveInFlight: Promise<void> | undefined;
+	dirty: boolean;
+}
+
+interface ReasoningCacheCleanupResult {
+	scanned: number;
+	deleted: number;
+	errors: number;
+}
+
+type ReasoningCacheCleanupTrigger = 'startup' | 'record';
+
+export interface ReasoningLookup {
+	getToolCallReasoning(toolCallId: string): string | undefined;
+	getPostToolReasoning(toolCallIds: readonly string[]): string | undefined;
+}
+
+export interface ReasoningRecorder {
+	readonly size: number;
+	recordToolCallReasoning(toolCallIds: readonly string[], text: string): void;
+	recordPostToolReasoning(toolCallIds: readonly string[], text: string): void;
+	prune(now?: number): ReasoningCachePruneResult;
+}
+
+export type SegmentReasoningCache = ReasoningLookup & ReasoningRecorder;
+
+export interface ReasoningCachePruneResult {
+	removed: number;
+	expired: number;
+}
+
+const REASONING_CACHE_SAVE_DEBOUNCE_MS = 500;
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
+
+function createToolReasoningKey(toolCallId: string): string {
 	return `tool:${toolCallId}`;
 }
 
-export function createPostToolReasoningKey(toolCallIds: readonly string[]): string {
+function createPostToolReasoningKey(toolCallIds: readonly string[]): string {
 	return `post-tool:${JSON.stringify(toolCallIds)}`;
 }
 
-export function pruneReasoningCache(cache: Map<string, ReasoningEntry>, clearAll: boolean): void {
-	if (clearAll) {
-		cache.clear();
-		return;
+export class ReasoningCacheStore {
+	private readonly cacheRootUri: vscode.Uri;
+	private cleanupPromise: Promise<void> = Promise.resolve();
+	private readonly segments = new Map<string, SegmentCacheState>();
+
+	constructor(globalStorageUri: vscode.Uri) {
+		this.cacheRootUri = vscode.Uri.joinPath(globalStorageUri, REASONING_CACHE_DIR_NAME);
+		void this.queueExpiredSegmentCleanup('startup');
 	}
 
-	if (cache.size <= MAX_CACHE_SIZE) {
-		return;
+	get size(): number {
+		let size = 0;
+		for (const state of this.segments.values()) {
+			size += state.cache.size;
+		}
+		return size;
 	}
 
-	// Evict oldest entries
-	const sorted = [...cache.entries()].sort((a, b) => a[1].timestamp - b[1].timestamp);
-	const toRemove = sorted.slice(0, sorted.length - MAX_CACHE_SIZE);
-	for (const [key] of toRemove) {
-		cache.delete(key);
+	async forSegment(segmentId: string): Promise<SegmentReasoningCache> {
+		await this.cleanupPromise;
+		const state = this.getOrCreateSegmentState(segmentId);
+		await state.readyPromise;
+
+		const getSize = () => state.cache.size;
+		return {
+			get size(): number {
+				return getSize();
+			},
+			getToolCallReasoning: (toolCallId) =>
+				this.get(state, createToolReasoningKey(toolCallId))?.text,
+			getPostToolReasoning: (toolCallIds) =>
+				this.get(state, createPostToolReasoningKey(toolCallIds))?.text,
+			recordToolCallReasoning: (toolCallIds, text) => {
+				const updatedAt = Date.now();
+				for (const toolCallId of toolCallIds) {
+					this.set(state, createToolReasoningKey(toolCallId), text, updatedAt);
+				}
+				void this.queueExpiredSegmentCleanup('record');
+			},
+			recordPostToolReasoning: (toolCallIds, text) => {
+				this.set(state, createPostToolReasoningKey(toolCallIds), text, Date.now());
+				void this.queueExpiredSegmentCleanup('record');
+			},
+			prune: (now) => this.pruneSegment(state, now),
+		};
+	}
+
+	private get(state: SegmentCacheState, reasoningKey: string): ReasoningEntry | undefined {
+		const entry = state.cache.get(reasoningKey);
+		if (!entry) {
+			return undefined;
+		}
+
+		entry.updatedAt = Date.now();
+		this.scheduleSave(state);
+		return entry;
+	}
+
+	private set(
+		state: SegmentCacheState,
+		reasoningKey: string,
+		text: string,
+		updatedAt = Date.now(),
+	): void {
+		state.cache.set(reasoningKey, { text, updatedAt });
+		this.scheduleSave(state);
+	}
+
+	private pruneSegment(state: SegmentCacheState, now = Date.now()): ReasoningCachePruneResult {
+		const result = pruneReasoningCache(state.cache, now);
+		if (result.removed > 0) {
+			logger.info(
+				`reasoningCache prune segment=${state.segmentId}` +
+					` removed=${result.removed} expired=${result.expired}` +
+					` ttlMs=${REASONING_CACHE_TTL_MS}`,
+			);
+			this.scheduleSave(state);
+		}
+		return result;
+	}
+
+	async flush(): Promise<void> {
+		await this.cleanupPromise;
+		await Promise.all([...this.segments.values()].map((state) => this.flushSegment(state)));
+	}
+
+	private getOrCreateSegmentState(segmentId: string): SegmentCacheState {
+		const existing = this.segments.get(segmentId);
+		if (existing) {
+			return existing;
+		}
+
+		const state: SegmentCacheState = {
+			segmentId,
+			cacheUri: vscode.Uri.joinPath(this.cacheRootUri, `${segmentId}.json`),
+			cache: new Map<string, ReasoningEntry>(),
+			readyPromise: Promise.resolve(),
+			saveTimer: undefined,
+			saveInFlight: undefined,
+			dirty: false,
+		};
+		state.readyPromise = this.loadSegment(state);
+		this.segments.set(segmentId, state);
+		return state;
+	}
+
+	private async flushSegment(state: SegmentCacheState): Promise<void> {
+		await state.readyPromise;
+
+		if (state.saveTimer) {
+			clearTimeout(state.saveTimer);
+			state.saveTimer = undefined;
+		}
+
+		if (state.saveInFlight) {
+			await state.saveInFlight;
+		}
+
+		if (!state.dirty) {
+			return;
+		}
+
+		state.dirty = false;
+		state.saveInFlight = (async () => {
+			try {
+				if (state.cache.size === 0) {
+					await deleteFileIfExists(state.cacheUri);
+					return;
+				}
+
+				await vscode.workspace.fs.createDirectory(this.cacheRootUri);
+				await vscode.workspace.fs.writeFile(
+					state.cacheUri,
+					textEncoder.encode(JSON.stringify(toPersistentSnapshot(state.cache))),
+				);
+			} catch (error) {
+				state.dirty = true;
+				logger.warn(`Failed to persist reasoning cache segment=${state.segmentId}`, error);
+			} finally {
+				state.saveInFlight = undefined;
+			}
+		})();
+
+		await state.saveInFlight;
+	}
+
+	private async loadSegment(state: SegmentCacheState): Promise<void> {
+		let data: Uint8Array;
+		try {
+			data = await vscode.workspace.fs.readFile(state.cacheUri);
+		} catch (error) {
+			if (!isFileNotFoundError(error)) {
+				logger.warn(`Failed to load reasoning cache segment=${state.segmentId}`, error);
+			}
+			return;
+		}
+
+		let snapshot: unknown;
+		try {
+			snapshot = JSON.parse(textDecoder.decode(data)) as unknown;
+		} catch (error) {
+			logger.warn(`Ignoring invalid reasoning cache file segment=${state.segmentId}`, error);
+			return;
+		}
+
+		if (!Array.isArray(snapshot)) {
+			logger.warn(`Ignoring invalid reasoning cache snapshot segment=${state.segmentId}`);
+			return;
+		}
+
+		for (const item of snapshot) {
+			if (!Array.isArray(item) || item.length !== 3) {
+				continue;
+			}
+
+			const [key, text, updatedAt] = item as [unknown, unknown, unknown];
+			if (typeof key !== 'string' || typeof text !== 'string') {
+				continue;
+			}
+			if (typeof updatedAt !== 'number' || !Number.isFinite(updatedAt)) {
+				continue;
+			}
+
+			state.cache.set(key, { text, updatedAt });
+		}
+
+		const pruneResult = this.pruneSegment(state);
+		if (pruneResult.removed > 0) {
+			this.scheduleSave(state);
+		}
+	}
+
+	private scheduleSave(state: SegmentCacheState): void {
+		state.dirty = true;
+		if (state.saveTimer) {
+			return;
+		}
+
+		state.saveTimer = setTimeout(() => {
+			state.saveTimer = undefined;
+			void this.flushSegment(state);
+		}, REASONING_CACHE_SAVE_DEBOUNCE_MS);
+	}
+
+	private queueExpiredSegmentCleanup(trigger: ReasoningCacheCleanupTrigger): Promise<void> {
+		const next = this.cleanupPromise
+			.then(() => this.pruneExpiredSegmentFiles(trigger))
+			.catch((error) => {
+				logger.warn(`Failed to run reasoning cache cleanup trigger=${trigger}`, error);
+			});
+		this.cleanupPromise = next;
+		return next;
+	}
+
+	private async pruneExpiredSegmentFiles(trigger: ReasoningCacheCleanupTrigger): Promise<void> {
+		let entries: [string, vscode.FileType][];
+		try {
+			entries = await vscode.workspace.fs.readDirectory(this.cacheRootUri);
+		} catch (error) {
+			if (!isFileNotFoundError(error)) {
+				logger.warn('Failed to scan reasoning cache directory', error);
+			}
+			return;
+		}
+
+		const now = Date.now();
+		const result: ReasoningCacheCleanupResult = {
+			scanned: 0,
+			deleted: 0,
+			errors: 0,
+		};
+		await Promise.all(
+			entries.map(async ([name, type]) => {
+				if (type !== vscode.FileType.File || !name.endsWith('.json')) {
+					return;
+				}
+
+				result.scanned += 1;
+				const segmentId = name.slice(0, -'.json'.length);
+				if (this.segments.has(segmentId)) {
+					return;
+				}
+
+				const uri = vscode.Uri.joinPath(this.cacheRootUri, name);
+				try {
+					const stat = await vscode.workspace.fs.stat(uri);
+					if (now - stat.mtime > REASONING_CACHE_TTL_MS) {
+						await vscode.workspace.fs.delete(uri);
+						result.deleted += 1;
+					}
+				} catch (error) {
+					if (!isFileNotFoundError(error)) {
+						result.errors += 1;
+						logger.warn(`Failed to prune reasoning cache file name=${name}`, error);
+					}
+				}
+			}),
+		);
+
+		if (shouldLogCleanupResult(trigger, result)) {
+			logger.info(
+				`reasoningCache cleanup trigger=${trigger}` +
+					` scanned=${result.scanned} deleted=${result.deleted} errors=${result.errors}` +
+					` ttlMs=${REASONING_CACHE_TTL_MS}`,
+			);
+		}
+	}
+}
+
+function shouldLogCleanupResult(
+	trigger: ReasoningCacheCleanupTrigger,
+	result: ReasoningCacheCleanupResult,
+): boolean {
+	return trigger === 'startup' || result.deleted > 0 || result.errors > 0;
+}
+
+export function pruneReasoningCache(
+	cache: Map<string, ReasoningEntry>,
+	now = Date.now(),
+): ReasoningCachePruneResult {
+	let expired = 0;
+	for (const [key, entry] of cache) {
+		if (now - entry.updatedAt > REASONING_CACHE_TTL_MS) {
+			cache.delete(key);
+			expired += 1;
+		}
+	}
+
+	return {
+		removed: expired,
+		expired,
+	};
+}
+
+function toPersistentSnapshot(cache: Map<string, ReasoningEntry>): PersistentReasoningSnapshot {
+	return [...cache.entries()].map(([key, entry]) => [key, entry.text, entry.updatedAt]);
+}
+
+function isFileNotFoundError(error: unknown): boolean {
+	return (error as { code?: unknown })?.code === 'FileNotFound';
+}
+
+async function deleteFileIfExists(uri: vscode.Uri): Promise<void> {
+	try {
+		await vscode.workspace.fs.delete(uri);
+	} catch (error) {
+		if (!isFileNotFoundError(error)) {
+			throw error;
+		}
 	}
 }

--- a/src/provider/cache.ts
+++ b/src/provider/cache.ts
@@ -246,11 +246,23 @@ export class ReasoningCacheStore {
 			snapshot = JSON.parse(textDecoder.decode(data)) as unknown;
 		} catch (error) {
 			logger.warn(`Ignoring invalid reasoning cache file segment=${state.segmentId}`, error);
+			await deleteFileIfExists(state.cacheUri).catch((deleteError) => {
+				logger.warn(
+					`Failed to delete invalid reasoning cache file segment=${state.segmentId}`,
+					deleteError,
+				);
+			});
 			return;
 		}
 
 		if (!Array.isArray(snapshot)) {
 			logger.warn(`Ignoring invalid reasoning cache snapshot segment=${state.segmentId}`);
+			await deleteFileIfExists(state.cacheUri).catch((deleteError) => {
+				logger.warn(
+					`Failed to delete invalid reasoning cache file segment=${state.segmentId}`,
+					deleteError,
+				);
+			});
 			return;
 		}
 

--- a/src/provider/cache.ts
+++ b/src/provider/cache.ts
@@ -31,7 +31,6 @@ interface SegmentCacheState {
 	saveInFlight: Promise<void> | undefined;
 	dirty: boolean;
 	lastAccessedAt: number;
-	activeReferences: number;
 }
 
 interface ReasoningCacheCleanupResult {
@@ -54,9 +53,7 @@ export interface ReasoningRecorder {
 	prune(now?: number): ReasoningCachePruneResult;
 }
 
-export interface SegmentReasoningCache extends ReasoningLookup, ReasoningRecorder {
-	release(): Promise<void>;
-}
+export type SegmentReasoningCache = ReasoningLookup & ReasoningRecorder;
 
 export interface ReasoningCachePruneResult {
 	removed: number;
@@ -65,7 +62,6 @@ export interface ReasoningCachePruneResult {
 
 const REASONING_CACHE_SAVE_DEBOUNCE_MS = 500;
 const REASONING_CACHE_TOUCH_INTERVAL_MS = REASONING_CACHE_TTL_MS / 2;
-const REASONING_CACHE_CLEANUP_CONCURRENCY = 8;
 const textEncoder = new TextEncoder();
 const textDecoder = new TextDecoder();
 
@@ -98,12 +94,10 @@ export class ReasoningCacheStore {
 	async forSegment(segmentId: string): Promise<SegmentReasoningCache> {
 		await this.cleanupPromise;
 		const state = this.getOrCreateSegmentState(segmentId);
-		state.activeReferences += 1;
 		await state.readyPromise;
 		this.markAccessed(state);
 
 		const getSize = () => state.cache.size;
-		let released = false;
 		return {
 			get size(): number {
 				return getSize();
@@ -124,13 +118,6 @@ export class ReasoningCacheStore {
 				void this.queueExpiredSegmentCleanup('record');
 			},
 			prune: (now) => this.pruneSegment(state, now),
-			release: async () => {
-				if (released) {
-					return;
-				}
-				released = true;
-				await this.releaseSegmentState(state);
-			},
 		};
 	}
 
@@ -162,12 +149,6 @@ export class ReasoningCacheStore {
 
 	private markAccessed(state: SegmentCacheState, now = Date.now()): void {
 		state.lastAccessedAt = now;
-	}
-
-	private async releaseSegmentState(state: SegmentCacheState): Promise<void> {
-		state.activeReferences = Math.max(0, state.activeReferences - 1);
-		this.markAccessed(state);
-		await this.unloadEmptySegment(state, false);
 	}
 
 	private pruneSegment(state: SegmentCacheState, now = Date.now()): ReasoningCachePruneResult {
@@ -203,7 +184,6 @@ export class ReasoningCacheStore {
 			saveInFlight: undefined,
 			dirty: false,
 			lastAccessedAt: Date.now(),
-			activeReferences: 0,
 		};
 		state.readyPromise = this.loadSegment(state);
 		this.segments.set(segmentId, state);
@@ -330,16 +310,43 @@ export class ReasoningCacheStore {
 		}
 
 		const now = Date.now();
-		const fileResults: ReasoningCacheCleanupResult[] = [];
-		for (let index = 0; index < entries.length; index += REASONING_CACHE_CLEANUP_CONCURRENCY) {
-			const batch = entries.slice(index, index + REASONING_CACHE_CLEANUP_CONCURRENCY);
-			fileResults.push(
-				...(await Promise.all(
-					batch.map(([name, type]) => this.pruneExpiredSegmentFile(name, type, now)),
-				)),
-			);
-		}
-		const result = fileResults.reduce(addCleanupResults, emptyCleanupResult());
+		const result: ReasoningCacheCleanupResult = {
+			scanned: 0,
+			deleted: 0,
+			errors: 0,
+		};
+		await Promise.all(
+			entries.map(async ([name, type]) => {
+				if (type !== vscode.FileType.File || !name.endsWith('.json')) {
+					return;
+				}
+
+				result.scanned += 1;
+				const segmentId = name.slice(0, -'.json'.length);
+				const loadedState = this.segments.get(segmentId);
+				if (loadedState) {
+					const deleted = await this.pruneLoadedSegmentFile(loadedState, now);
+					if (deleted) {
+						result.deleted += 1;
+					}
+					return;
+				}
+
+				const uri = vscode.Uri.joinPath(this.cacheRootUri, name);
+				try {
+					const stat = await vscode.workspace.fs.stat(uri);
+					if (now - stat.mtime > REASONING_CACHE_TTL_MS) {
+						await vscode.workspace.fs.delete(uri);
+						result.deleted += 1;
+					}
+				} catch (error) {
+					if (!isFileNotFoundError(error)) {
+						result.errors += 1;
+						logger.warn(`Failed to prune reasoning cache file name=${name}`, error);
+					}
+				}
+			}),
+		);
 		await this.unloadInactiveEmptySegments(now);
 
 		if (shouldLogCleanupResult(trigger, result)) {
@@ -349,39 +356,6 @@ export class ReasoningCacheStore {
 					` ttlMs=${REASONING_CACHE_TTL_MS}`,
 			);
 		}
-	}
-
-	private async pruneExpiredSegmentFile(
-		name: string,
-		type: vscode.FileType,
-		now: number,
-	): Promise<ReasoningCacheCleanupResult> {
-		if (type !== vscode.FileType.File || !name.endsWith('.json')) {
-			return emptyCleanupResult();
-		}
-
-		const segmentId = name.slice(0, -'.json'.length);
-		const loadedState = this.segments.get(segmentId);
-		if (loadedState) {
-			const deleted = await this.pruneLoadedSegmentFile(loadedState, now);
-			return { scanned: 1, deleted: deleted ? 1 : 0, errors: 0 };
-		}
-
-		const uri = vscode.Uri.joinPath(this.cacheRootUri, name);
-		try {
-			const stat = await vscode.workspace.fs.stat(uri);
-			if (now - stat.mtime > REASONING_CACHE_TTL_MS) {
-				await vscode.workspace.fs.delete(uri);
-				return { scanned: 1, deleted: 1, errors: 0 };
-			}
-		} catch (error) {
-			if (!isFileNotFoundError(error)) {
-				logger.warn(`Failed to prune reasoning cache file name=${name}`, error);
-				return { scanned: 1, deleted: 0, errors: 1 };
-			}
-		}
-
-		return { scanned: 1, deleted: 0, errors: 0 };
 	}
 
 	private async pruneLoadedSegmentFile(state: SegmentCacheState, now: number): Promise<boolean> {
@@ -404,17 +378,7 @@ export class ReasoningCacheStore {
 		now: number,
 		deletePersistedFile: boolean,
 	): Promise<boolean> {
-		if (now - state.lastAccessedAt <= REASONING_CACHE_TTL_MS) {
-			return false;
-		}
-		return this.unloadEmptySegment(state, deletePersistedFile);
-	}
-
-	private async unloadEmptySegment(
-		state: SegmentCacheState,
-		deletePersistedFile: boolean,
-	): Promise<boolean> {
-		if (state.activeReferences > 0 || state.cache.size > 0) {
+		if (state.cache.size > 0 || now - state.lastAccessedAt <= REASONING_CACHE_TTL_MS) {
 			return false;
 		}
 
@@ -425,7 +389,7 @@ export class ReasoningCacheStore {
 			await this.flushSegment(state);
 		}
 
-		if (state.activeReferences === 0 && state.cache.size === 0 && !state.dirty) {
+		if (state.cache.size === 0 && !state.dirty) {
 			this.segments.delete(state.segmentId);
 			return deletePersistedFile;
 		}
@@ -439,21 +403,6 @@ function shouldLogCleanupResult(
 	result: ReasoningCacheCleanupResult,
 ): boolean {
 	return trigger === 'startup' || result.deleted > 0 || result.errors > 0;
-}
-
-function emptyCleanupResult(): ReasoningCacheCleanupResult {
-	return { scanned: 0, deleted: 0, errors: 0 };
-}
-
-function addCleanupResults(
-	total: ReasoningCacheCleanupResult,
-	current: ReasoningCacheCleanupResult,
-): ReasoningCacheCleanupResult {
-	return {
-		scanned: total.scanned + current.scanned,
-		deleted: total.deleted + current.deleted,
-		errors: total.errors + current.errors,
-	};
 }
 
 export function pruneReasoningCache(

--- a/src/provider/cache.ts
+++ b/src/provider/cache.ts
@@ -65,6 +65,7 @@ export interface ReasoningCachePruneResult {
 
 const REASONING_CACHE_SAVE_DEBOUNCE_MS = 500;
 const REASONING_CACHE_TOUCH_INTERVAL_MS = REASONING_CACHE_TTL_MS / 2;
+const REASONING_CACHE_CLEANUP_CONCURRENCY = 8;
 const textEncoder = new TextEncoder();
 const textDecoder = new TextDecoder();
 
@@ -329,35 +330,15 @@ export class ReasoningCacheStore {
 		}
 
 		const now = Date.now();
-		const fileResults = await Promise.all(
-			entries.map(async ([name, type]): Promise<ReasoningCacheCleanupResult> => {
-				if (type !== vscode.FileType.File || !name.endsWith('.json')) {
-					return emptyCleanupResult();
-				}
-
-				const segmentId = name.slice(0, -'.json'.length);
-				const loadedState = this.segments.get(segmentId);
-				if (loadedState) {
-					const deleted = await this.pruneLoadedSegmentFile(loadedState, now);
-					return { scanned: 1, deleted: deleted ? 1 : 0, errors: 0 };
-				}
-
-				const uri = vscode.Uri.joinPath(this.cacheRootUri, name);
-				try {
-					const stat = await vscode.workspace.fs.stat(uri);
-					if (now - stat.mtime > REASONING_CACHE_TTL_MS) {
-						await vscode.workspace.fs.delete(uri);
-						return { scanned: 1, deleted: 1, errors: 0 };
-					}
-				} catch (error) {
-					if (!isFileNotFoundError(error)) {
-						logger.warn(`Failed to prune reasoning cache file name=${name}`, error);
-						return { scanned: 1, deleted: 0, errors: 1 };
-					}
-				}
-				return { scanned: 1, deleted: 0, errors: 0 };
-			}),
-		);
+		const fileResults: ReasoningCacheCleanupResult[] = [];
+		for (let index = 0; index < entries.length; index += REASONING_CACHE_CLEANUP_CONCURRENCY) {
+			const batch = entries.slice(index, index + REASONING_CACHE_CLEANUP_CONCURRENCY);
+			fileResults.push(
+				...(await Promise.all(
+					batch.map(([name, type]) => this.pruneExpiredSegmentFile(name, type, now)),
+				)),
+			);
+		}
 		const result = fileResults.reduce(addCleanupResults, emptyCleanupResult());
 		await this.unloadInactiveEmptySegments(now);
 
@@ -368,6 +349,39 @@ export class ReasoningCacheStore {
 					` ttlMs=${REASONING_CACHE_TTL_MS}`,
 			);
 		}
+	}
+
+	private async pruneExpiredSegmentFile(
+		name: string,
+		type: vscode.FileType,
+		now: number,
+	): Promise<ReasoningCacheCleanupResult> {
+		if (type !== vscode.FileType.File || !name.endsWith('.json')) {
+			return emptyCleanupResult();
+		}
+
+		const segmentId = name.slice(0, -'.json'.length);
+		const loadedState = this.segments.get(segmentId);
+		if (loadedState) {
+			const deleted = await this.pruneLoadedSegmentFile(loadedState, now);
+			return { scanned: 1, deleted: deleted ? 1 : 0, errors: 0 };
+		}
+
+		const uri = vscode.Uri.joinPath(this.cacheRootUri, name);
+		try {
+			const stat = await vscode.workspace.fs.stat(uri);
+			if (now - stat.mtime > REASONING_CACHE_TTL_MS) {
+				await vscode.workspace.fs.delete(uri);
+				return { scanned: 1, deleted: 1, errors: 0 };
+			}
+		} catch (error) {
+			if (!isFileNotFoundError(error)) {
+				logger.warn(`Failed to prune reasoning cache file name=${name}`, error);
+				return { scanned: 1, deleted: 0, errors: 1 };
+			}
+		}
+
+		return { scanned: 1, deleted: 0, errors: 0 };
 	}
 
 	private async pruneLoadedSegmentFile(state: SegmentCacheState, now: number): Promise<boolean> {

--- a/src/provider/cache.ts
+++ b/src/provider/cache.ts
@@ -30,6 +30,7 @@ interface SegmentCacheState {
 	saveTimer: NodeJS.Timeout | undefined;
 	saveInFlight: Promise<void> | undefined;
 	dirty: boolean;
+	lastAccessedAt: number;
 }
 
 interface ReasoningCacheCleanupResult {
@@ -94,6 +95,7 @@ export class ReasoningCacheStore {
 		await this.cleanupPromise;
 		const state = this.getOrCreateSegmentState(segmentId);
 		await state.readyPromise;
+		this.markAccessed(state);
 
 		const getSize = () => state.cache.size;
 		return {
@@ -126,6 +128,7 @@ export class ReasoningCacheStore {
 		}
 
 		const now = Date.now();
+		this.markAccessed(state, now);
 		if (now - entry.updatedAt >= REASONING_CACHE_TOUCH_INTERVAL_MS) {
 			entry.updatedAt = now;
 			this.scheduleSave(state);
@@ -139,8 +142,13 @@ export class ReasoningCacheStore {
 		text: string,
 		updatedAt = Date.now(),
 	): void {
+		this.markAccessed(state, updatedAt);
 		state.cache.set(reasoningKey, { text, updatedAt });
 		this.scheduleSave(state);
+	}
+
+	private markAccessed(state: SegmentCacheState, now = Date.now()): void {
+		state.lastAccessedAt = now;
 	}
 
 	private pruneSegment(state: SegmentCacheState, now = Date.now()): ReasoningCachePruneResult {
@@ -175,6 +183,7 @@ export class ReasoningCacheStore {
 			saveTimer: undefined,
 			saveInFlight: undefined,
 			dirty: false,
+			lastAccessedAt: Date.now(),
 		};
 		state.readyPromise = this.loadSegment(state);
 		this.segments.set(segmentId, state);
@@ -314,7 +323,12 @@ export class ReasoningCacheStore {
 
 				result.scanned += 1;
 				const segmentId = name.slice(0, -'.json'.length);
-				if (this.segments.has(segmentId)) {
+				const loadedState = this.segments.get(segmentId);
+				if (loadedState) {
+					const deleted = await this.pruneLoadedSegmentFile(loadedState, now);
+					if (deleted) {
+						result.deleted += 1;
+					}
 					return;
 				}
 
@@ -333,6 +347,7 @@ export class ReasoningCacheStore {
 				}
 			}),
 		);
+		await this.unloadInactiveEmptySegments(now);
 
 		if (shouldLogCleanupResult(trigger, result)) {
 			logger.info(
@@ -341,6 +356,45 @@ export class ReasoningCacheStore {
 					` ttlMs=${REASONING_CACHE_TTL_MS}`,
 			);
 		}
+	}
+
+	private async pruneLoadedSegmentFile(state: SegmentCacheState, now: number): Promise<boolean> {
+		await state.readyPromise;
+		this.pruneSegment(state, now);
+		return this.unloadInactiveEmptySegment(state, now, true);
+	}
+
+	private async unloadInactiveEmptySegments(now: number): Promise<void> {
+		await Promise.all(
+			[...this.segments.values()].map(async (state) => {
+				await state.readyPromise;
+				await this.unloadInactiveEmptySegment(state, now, false);
+			}),
+		);
+	}
+
+	private async unloadInactiveEmptySegment(
+		state: SegmentCacheState,
+		now: number,
+		deletePersistedFile: boolean,
+	): Promise<boolean> {
+		if (state.cache.size > 0 || now - state.lastAccessedAt <= REASONING_CACHE_TTL_MS) {
+			return false;
+		}
+
+		if (deletePersistedFile) {
+			this.scheduleSave(state);
+		}
+		if (state.dirty || state.saveTimer || state.saveInFlight) {
+			await this.flushSegment(state);
+		}
+
+		if (state.cache.size === 0 && !state.dirty) {
+			this.segments.delete(state.segmentId);
+			return deletePersistedFile;
+		}
+
+		return false;
 	}
 }
 

--- a/src/provider/cache.ts
+++ b/src/provider/cache.ts
@@ -417,7 +417,7 @@ function shouldLogCleanupResult(
 	return trigger === 'startup' || result.deleted > 0 || result.errors > 0;
 }
 
-export function pruneReasoningCache(
+function pruneReasoningCache(
 	cache: Map<string, ReasoningEntry>,
 	now = Date.now(),
 ): ReasoningCachePruneResult {

--- a/src/provider/convert.ts
+++ b/src/provider/convert.ts
@@ -1,7 +1,7 @@
 import vscode from 'vscode';
 import { safeStringify } from '../json';
 import type { DeepSeekMessage, DeepSeekTool, DeepSeekToolCall } from '../types';
-import { createPostToolReasoningKey, createToolReasoningKey, type ReasoningEntry } from './cache';
+import type { ReasoningLookup } from './cache';
 
 /**
  * Convert VS Code chat messages to DeepSeek format.
@@ -11,7 +11,7 @@ import { createPostToolReasoningKey, createToolReasoningKey, type ReasoningEntry
 export function convertMessages(
 	messages: readonly vscode.LanguageModelChatRequestMessage[],
 	isThinkingModel: boolean,
-	reasoningCache: Map<string, ReasoningEntry>,
+	reasoningLookup: ReasoningLookup,
 ): DeepSeekMessage[] {
 	const result: DeepSeekMessage[] = [];
 	let recentToolResultIds: string[] = [];
@@ -55,19 +55,14 @@ export function convertMessages(
 			let reasoningContent: string | undefined;
 			if (isThinkingModel && toolCalls.length > 0) {
 				for (const tc of toolCalls) {
-					// Prefer new `tool:<callId>` key; fallback to bare `callId` for entries written
-					// before the stable-key change (read-only compat, no new bare-key writes).
-					const cached =
-						reasoningCache.get(createToolReasoningKey(tc.id)) ?? reasoningCache.get(tc.id);
+					const cached = reasoningLookup.getToolCallReasoning(tc.id);
 					if (cached) {
-						reasoningContent = cached.text;
+						reasoningContent = cached;
 						break;
 					}
 				}
 			} else if (isThinkingModel && recentToolResultIds.length > 0) {
-				reasoningContent = reasoningCache.get(
-					createPostToolReasoningKey(recentToolResultIds),
-				)?.text;
+				reasoningContent = reasoningLookup.getPostToolReasoning(recentToolResultIds);
 			}
 
 			if (content || toolCalls.length > 0) {

--- a/src/provider/diagnostics.ts
+++ b/src/provider/diagnostics.ts
@@ -4,7 +4,7 @@ import { getDebugLoggingEnabled } from '../config';
 import {
 	IMAGE_DESCRIPTION_UNAVAILABLE,
 	LANGUAGE_MODEL_CHAT_SYSTEM_ROLE,
-	MAX_CACHE_SIZE,
+	REASONING_CACHE_TTL_MS,
 } from '../consts';
 import { logger } from '../logger';
 import type { DeepSeekMessage, DeepSeekRequest, DeepSeekTool, DeepSeekUsage } from '../types';
@@ -176,7 +176,6 @@ export function observeCancellationToken(
 
 export interface CacheDiagnosticsRecorder {
 	isEnabled(): boolean;
-	logReasoningCacheCleared(removed: number): void;
 	beginRequest(options: BeginCacheDiagnosticsOptions): CacheDiagnosticsRun;
 }
 
@@ -219,12 +218,6 @@ class DefaultCacheDiagnosticsRecorder implements CacheDiagnosticsRecorder {
 		return getDebugLoggingEnabled();
 	}
 
-	logReasoningCacheCleared(removed: number): void {
-		if (removed > 0 && this.isEnabled()) {
-			logger.info(`reasoning-cache cleared entries=${removed} reason=short-history`);
-		}
-	}
-
 	beginRequest(options: BeginCacheDiagnosticsOptions): CacheDiagnosticsRun {
 		if (!this.isEnabled()) {
 			this.clearCacheTraces();
@@ -255,7 +248,7 @@ class DefaultCacheDiagnosticsRecorder implements CacheDiagnosticsRecorder {
 				` thinking=${options.isThinkingModel}` +
 				` thinkingEffort=${options.thinkingEffort}` +
 				` maxTokens=${options.maxTokens ?? 'api-default'}` +
-				` reasoningCache(size=${options.reasoningCacheSize},max=${MAX_CACHE_SIZE})` +
+				` reasoningCache(size=${options.reasoningCacheSize},ttlHours=${formatReasoningCacheTtlHours()})` +
 				` inputMessages=${options.inputMessages.length}` +
 				` deepseekMessages=${options.request.messages.length}`,
 		);
@@ -351,7 +344,7 @@ class ActiveCacheDiagnosticsRun implements CacheDiagnosticsRun {
 	onDone(info: CacheDiagnosticsDoneInfo): void {
 		logger.info(
 			`[cache-trace #${this.requestId}] reasoningCache afterDone size=${info.reasoningCacheSize}` +
-				` max=${MAX_CACHE_SIZE}` +
+				` ttlHours=${formatReasoningCacheTtlHours()}` +
 				` evicted=${info.evictedReasoningEntries}` +
 				` emittedToolCalls=${info.emittedToolCalls}` +
 				` trailingToolResults=${info.trailingToolResults}`,
@@ -382,6 +375,10 @@ class ActiveCacheDiagnosticsRun implements CacheDiagnosticsRun {
 	onSegmentMarkerReport(info: SegmentMarkerReportInfo): void {
 		logger.info(`[cache-trace #${this.requestId}] ${formatSegmentMarkerReport(info)}`);
 	}
+}
+
+function formatReasoningCacheTtlHours(): number {
+	return REASONING_CACHE_TTL_MS / (60 * 60 * 1000);
 }
 
 class NoopCacheDiagnosticsRun implements CacheDiagnosticsRun {

--- a/src/provider/index.ts
+++ b/src/provider/index.ts
@@ -3,7 +3,7 @@ import { AuthManager } from '../auth';
 import { MODELS } from '../consts';
 import { t } from '../i18n';
 import { logger } from '../logger';
-import type { ReasoningEntry } from './cache';
+import { ReasoningCacheStore } from './cache';
 import { createCacheDiagnosticsRecorder } from './diagnostics';
 import { dumpProviderInput } from './dump';
 import { toChatInfo } from './models';
@@ -26,8 +26,8 @@ export class DeepSeekChatProvider implements vscode.LanguageModelChatProvider {
 	readonly onDidChangeLanguageModelChatInformation =
 		this.onDidChangeLanguageModelChatInformationEmitter.event;
 
-	/** reasoning text → tool_call IDs cache. */
-	private readonly reasoningCache = new Map<string, ReasoningEntry>();
+	/** Segment-scoped reasoning_content cache. */
+	private readonly reasoningCache: ReasoningCacheStore;
 	private readonly cacheDiagnostics = createCacheDiagnosticsRecorder();
 
 	/** Vision proxy: resolver + cached model. */
@@ -42,6 +42,7 @@ export class DeepSeekChatProvider implements vscode.LanguageModelChatProvider {
 	constructor(context: vscode.ExtensionContext) {
 		this.authManager = new AuthManager(context);
 		this.globalStorageUri = context.globalStorageUri;
+		this.reasoningCache = new ReasoningCacheStore(context.globalStorageUri);
 
 		context.subscriptions.push(
 			this.onDidChangeLanguageModelChatInformationEmitter,
@@ -100,6 +101,7 @@ export class DeepSeekChatProvider implements vscode.LanguageModelChatProvider {
 		// instead of leaving stale entries behind after deactivate. The returned
 		// model list itself is unused — we only call this for its side effect.
 		try {
+			await this.reasoningCache.flush();
 			await vscode.lm.selectChatModels({ vendor: 'deepseek' });
 		} catch (error) {
 			logger.warn('Failed to refresh DeepSeek models during deactivate', error);
@@ -133,6 +135,8 @@ export class DeepSeekChatProvider implements vscode.LanguageModelChatProvider {
 		token: vscode.CancellationToken,
 	): Promise<void> {
 		const segment = resolveConversationSegment(messages);
+		const reasoning = await this.reasoningCache.forSegment(segment.segmentId);
+		reasoning.prune();
 
 		dumpProviderInput({
 			globalStorageUri: this.globalStorageUri,
@@ -150,7 +154,8 @@ export class DeepSeekChatProvider implements vscode.LanguageModelChatProvider {
 			messages,
 			options,
 			token,
-			reasoningCache: this.reasoningCache,
+			reasoningLookup: reasoning,
+			reasoningCacheSize: reasoning.size,
 			cacheDiagnostics: this.cacheDiagnostics,
 			getVisionModel: () => this.vision.get(),
 		});
@@ -159,7 +164,7 @@ export class DeepSeekChatProvider implements vscode.LanguageModelChatProvider {
 			prepared,
 			progress,
 			token,
-			reasoningCache: this.reasoningCache,
+			reasoningRecorder: reasoning,
 			getCharsPerToken: () => this.charsPerToken,
 			setCharsPerToken: (charsPerToken) => {
 				this.charsPerToken = charsPerToken;

--- a/src/provider/index.ts
+++ b/src/provider/index.ts
@@ -101,10 +101,15 @@ export class DeepSeekChatProvider implements vscode.LanguageModelChatProvider {
 		// instead of leaving stale entries behind after deactivate. The returned
 		// model list itself is unused — we only call this for its side effect.
 		try {
-			await this.reasoningCache.flush();
 			await vscode.lm.selectChatModels({ vendor: 'deepseek' });
 		} catch (error) {
 			logger.warn('Failed to refresh DeepSeek models during deactivate', error);
+		}
+
+		try {
+			await this.reasoningCache.flush();
+		} catch (error) {
+			logger.warn('Failed to persist reasoning cache during deactivate', error);
 		}
 	}
 

--- a/src/provider/index.ts
+++ b/src/provider/index.ts
@@ -143,38 +143,42 @@ export class DeepSeekChatProvider implements vscode.LanguageModelChatProvider {
 		const reasoning = await this.reasoningCache.forSegment(segment.segmentId);
 		reasoning.prune();
 
-		dumpProviderInput({
-			globalStorageUri: this.globalStorageUri,
-			segment,
-			modelInfo,
-			messages,
-			requestOptions: options,
-		});
+		try {
+			dumpProviderInput({
+				globalStorageUri: this.globalStorageUri,
+				segment,
+				modelInfo,
+				messages,
+				requestOptions: options,
+			});
 
-		const prepared = await prepareChatRequest({
-			authManager: this.authManager,
-			globalStorageUri: this.globalStorageUri,
-			modelInfo,
-			segment,
-			messages,
-			options,
-			token,
-			reasoningLookup: reasoning,
-			reasoningCacheSize: reasoning.size,
-			cacheDiagnostics: this.cacheDiagnostics,
-			getVisionModel: () => this.vision.get(),
-		});
+			const prepared = await prepareChatRequest({
+				authManager: this.authManager,
+				globalStorageUri: this.globalStorageUri,
+				modelInfo,
+				segment,
+				messages,
+				options,
+				token,
+				reasoningLookup: reasoning,
+				reasoningCacheSize: reasoning.size,
+				cacheDiagnostics: this.cacheDiagnostics,
+				getVisionModel: () => this.vision.get(),
+			});
 
-		return streamChatCompletion({
-			prepared,
-			progress,
-			token,
-			reasoningRecorder: reasoning,
-			getCharsPerToken: () => this.charsPerToken,
-			setCharsPerToken: (charsPerToken) => {
-				this.charsPerToken = charsPerToken;
-			},
-		});
+			return streamChatCompletion({
+				prepared,
+				progress,
+				token,
+				reasoningRecorder: reasoning,
+				getCharsPerToken: () => this.charsPerToken,
+				setCharsPerToken: (charsPerToken) => {
+					this.charsPerToken = charsPerToken;
+				},
+			});
+		} finally {
+			await reasoning.release();
+		}
 	}
 
 	async provideTokenCount(

--- a/src/provider/index.ts
+++ b/src/provider/index.ts
@@ -143,42 +143,38 @@ export class DeepSeekChatProvider implements vscode.LanguageModelChatProvider {
 		const reasoning = await this.reasoningCache.forSegment(segment.segmentId);
 		reasoning.prune();
 
-		try {
-			dumpProviderInput({
-				globalStorageUri: this.globalStorageUri,
-				segment,
-				modelInfo,
-				messages,
-				requestOptions: options,
-			});
+		dumpProviderInput({
+			globalStorageUri: this.globalStorageUri,
+			segment,
+			modelInfo,
+			messages,
+			requestOptions: options,
+		});
 
-			const prepared = await prepareChatRequest({
-				authManager: this.authManager,
-				globalStorageUri: this.globalStorageUri,
-				modelInfo,
-				segment,
-				messages,
-				options,
-				token,
-				reasoningLookup: reasoning,
-				reasoningCacheSize: reasoning.size,
-				cacheDiagnostics: this.cacheDiagnostics,
-				getVisionModel: () => this.vision.get(),
-			});
+		const prepared = await prepareChatRequest({
+			authManager: this.authManager,
+			globalStorageUri: this.globalStorageUri,
+			modelInfo,
+			segment,
+			messages,
+			options,
+			token,
+			reasoningLookup: reasoning,
+			reasoningCacheSize: reasoning.size,
+			cacheDiagnostics: this.cacheDiagnostics,
+			getVisionModel: () => this.vision.get(),
+		});
 
-			return streamChatCompletion({
-				prepared,
-				progress,
-				token,
-				reasoningRecorder: reasoning,
-				getCharsPerToken: () => this.charsPerToken,
-				setCharsPerToken: (charsPerToken) => {
-					this.charsPerToken = charsPerToken;
-				},
-			});
-		} finally {
-			await reasoning.release();
-		}
+		return streamChatCompletion({
+			prepared,
+			progress,
+			token,
+			reasoningRecorder: reasoning,
+			getCharsPerToken: () => this.charsPerToken,
+			setCharsPerToken: (charsPerToken) => {
+				this.charsPerToken = charsPerToken;
+			},
+		});
 	}
 
 	async provideTokenCount(

--- a/src/provider/request.ts
+++ b/src/provider/request.ts
@@ -5,7 +5,7 @@ import { getApiModelId, getBaseUrl, getMaxTokens } from '../config';
 import { MODELS } from '../consts';
 import { t } from '../i18n';
 import type { DeepSeekMessage, DeepSeekRequest } from '../types';
-import { pruneReasoningCache, type ReasoningEntry } from './cache';
+import type { ReasoningLookup } from './cache';
 import { convertMessages, convertTools, countMessageChars } from './convert';
 import type { CacheDiagnosticsRecorder, CacheDiagnosticsRun } from './diagnostics';
 import { dumpDeepSeekRequest } from './dump';
@@ -31,7 +31,8 @@ export interface PrepareChatRequestOptions {
 	messages: readonly vscode.LanguageModelChatRequestMessage[];
 	options: vscode.ProvideLanguageModelChatResponseOptions;
 	token: vscode.CancellationToken;
-	reasoningCache: Map<string, ReasoningEntry>;
+	reasoningLookup: ReasoningLookup;
+	reasoningCacheSize: number;
 	cacheDiagnostics: CacheDiagnosticsRecorder;
 	getVisionModel: () => Promise<vscode.LanguageModelChat | undefined>;
 }
@@ -44,7 +45,8 @@ export async function prepareChatRequest({
 	messages,
 	options,
 	token,
-	reasoningCache,
+	reasoningLookup,
+	reasoningCacheSize,
 	cacheDiagnostics,
 	getVisionModel,
 }: PrepareChatRequestOptions): Promise<PreparedChatRequest> {
@@ -59,12 +61,9 @@ export async function prepareChatRequest({
 	const thinkingEffort = getConfiguredThinkingEffort(options as ModelConfigurationOptions);
 	const maxTokens = getMaxTokens();
 
-	clearStaleReasoningCache(messages, reasoningCache, cacheDiagnostics);
-	const reasoningCacheSize = reasoningCache.size;
-
 	const visionResolution = await resolveImageMessages(messages, token, getVisionModel);
 	const resolvedMessages = visionResolution.messages;
-	const deepseekMessages = convertMessages(resolvedMessages, isThinkingModel, reasoningCache);
+	const deepseekMessages = convertMessages(resolvedMessages, isThinkingModel, reasoningLookup);
 	const tools = modelDef?.capabilities.toolCalling ? convertTools(options.tools) : undefined;
 
 	const totalRequestChars = countMessageChars(deepseekMessages);
@@ -133,16 +132,4 @@ function collectTrailingToolResultIds(messages: readonly DeepSeekMessage[]): str
 		trailingToolResultIds.push(message.tool_call_id);
 	}
 	return trailingToolResultIds.reverse();
-}
-
-function clearStaleReasoningCache(
-	messages: readonly vscode.LanguageModelChatRequestMessage[],
-	reasoningCache: Map<string, ReasoningEntry>,
-	cacheDiagnostics: CacheDiagnosticsRecorder,
-): void {
-	if (messages.length <= 2) {
-		const removed = reasoningCache.size;
-		pruneReasoningCache(reasoningCache, true);
-		cacheDiagnostics.logReasoningCacheCleared(removed);
-	}
 }

--- a/src/provider/stream.ts
+++ b/src/provider/stream.ts
@@ -1,12 +1,7 @@
 import vscode from 'vscode';
 import { logger } from '../logger';
 import type { DeepSeekToolCall, DeepSeekUsage } from '../types';
-import {
-	createPostToolReasoningKey,
-	createToolReasoningKey,
-	pruneReasoningCache,
-	type ReasoningEntry,
-} from './cache';
+import type { ReasoningRecorder } from './cache';
 import {
 	observeCancellationToken,
 	type CacheDiagnosticsRun,
@@ -27,7 +22,7 @@ export interface StreamChatCompletionOptions {
 	prepared: PreparedChatRequest;
 	progress: vscode.Progress<vscode.LanguageModelResponsePart>;
 	token: vscode.CancellationToken;
-	reasoningCache: Map<string, ReasoningEntry>;
+	reasoningRecorder: ReasoningRecorder;
 	getCharsPerToken: () => number;
 	setCharsPerToken: (charsPerToken: number) => void;
 }
@@ -36,7 +31,7 @@ export function streamChatCompletion({
 	prepared,
 	progress,
 	token,
-	reasoningCache,
+	reasoningRecorder,
 	getCharsPerToken,
 	setCharsPerToken,
 }: StreamChatCompletionOptions): Promise<void> {
@@ -46,7 +41,7 @@ export function streamChatCompletion({
 		segmentMarkerReported: false,
 	};
 	const cancelListener = observeCancellationToken(token, prepared.cacheDiagnostics, () => {
-		cacheEmittedToolCallReasoningOnCancellation(prepared.isThinkingModel, state, reasoningCache);
+		cacheEmittedToolCallReasoningOnCancellation(prepared.isThinkingModel, state, reasoningRecorder);
 	});
 
 	return prepared.client
@@ -78,7 +73,7 @@ export function streamChatCompletion({
 						prepared.isThinkingModel,
 						prepared.trailingToolResultIds,
 						state,
-						reasoningCache,
+						reasoningRecorder,
 						prepared.cacheDiagnostics,
 					);
 				},
@@ -203,29 +198,24 @@ function finalizeReasoningCache(
 	isThinkingModel: boolean,
 	trailingToolResultIds: readonly string[],
 	state: ResponseStreamState,
-	reasoningCache: Map<string, ReasoningEntry>,
+	reasoningRecorder: ReasoningRecorder,
 	cacheDiagnostics: CacheDiagnosticsRun,
 ): void {
 	if (isThinkingModel && state.accumulatedReasoning) {
-		const entry: ReasoningEntry = {
-			text: state.accumulatedReasoning,
-			timestamp: Date.now(),
-		};
 		if (state.emittedToolCallIds.length > 0) {
-			for (const toolCallId of state.emittedToolCallIds) {
-				reasoningCache.set(createToolReasoningKey(toolCallId), entry);
-			}
+			reasoningRecorder.recordToolCallReasoning(
+				state.emittedToolCallIds,
+				state.accumulatedReasoning,
+			);
 		} else if (trailingToolResultIds.length > 0) {
-			reasoningCache.set(createPostToolReasoningKey(trailingToolResultIds), entry);
+			reasoningRecorder.recordPostToolReasoning(trailingToolResultIds, state.accumulatedReasoning);
 		}
 	}
 
-	const cacheSizeBeforePrune = reasoningCache.size;
-	pruneReasoningCache(reasoningCache, false);
-	const evictedReasoningEntries = Math.max(0, cacheSizeBeforePrune - reasoningCache.size);
+	const pruneResult = reasoningRecorder.prune();
 	cacheDiagnostics.onDone({
-		reasoningCacheSize: reasoningCache.size,
-		evictedReasoningEntries,
+		reasoningCacheSize: reasoningRecorder.size,
+		evictedReasoningEntries: pruneResult.removed,
 		emittedToolCalls: state.emittedToolCallIds.length,
 		trailingToolResults: trailingToolResultIds.length,
 	});
@@ -234,20 +224,14 @@ function finalizeReasoningCache(
 function cacheEmittedToolCallReasoningOnCancellation(
 	isThinkingModel: boolean,
 	state: ResponseStreamState,
-	reasoningCache: Map<string, ReasoningEntry>,
+	reasoningRecorder: ReasoningRecorder,
 ): void {
 	if (!isThinkingModel || !state.accumulatedReasoning || state.emittedToolCallIds.length === 0) {
 		return;
 	}
 
-	const entry: ReasoningEntry = {
-		text: state.accumulatedReasoning,
-		timestamp: Date.now(),
-	};
-	for (const toolCallId of state.emittedToolCallIds) {
-		reasoningCache.set(createToolReasoningKey(toolCallId), entry);
-	}
-	pruneReasoningCache(reasoningCache, false);
+	reasoningRecorder.recordToolCallReasoning(state.emittedToolCallIds, state.accumulatedReasoning);
+	reasoningRecorder.prune();
 }
 
 function updateCharsPerToken(


### PR DESCRIPTION
## Summary
- Persist DeepSeek `reasoning_content` by conversation segment under `globalStorageUri`.
- Replay cached reasoning for tool-call and post-tool messages through narrow lookup/recorder interfaces.
- Use a 72h TTL with startup cleanup and opportunistic cleanup after new reasoning is recorded.
- Store each segment in its own cache file and skip currently loaded segment files during directory cleanup.

## Tests
- `npm run compile`
- `npm run lint`
- `npm run format:check`
- Manual 72h persistence/reload/per-segment flow
- Manual 60s expiration cleanup flow
- Manual record-trigger cleanup in minimal output mode