### PR TITLE
Fix diagnostics log visibility

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -9,10 +9,6 @@ function getChannel(): vscode.LogOutputChannel {
 	return channel;
 }
 
-function ts(): string {
-	return new Date().toISOString().slice(11, 23);
-}
-
 function formatMessage(args: unknown[]): string {
 	return args
 		.map((a) => {
@@ -28,10 +24,10 @@ function formatMessage(args: unknown[]): string {
 }
 
 export const logger = {
-	info: (...args: unknown[]) => getChannel().info(`[${ts()}]`, formatMessage(args)),
-	warn: (...args: unknown[]) => getChannel().warn(`[${ts()}]`, formatMessage(args)),
-	error: (...args: unknown[]) => getChannel().error(`[${ts()}]`, formatMessage(args)),
-	debug: (...args: unknown[]) => getChannel().debug(`[${ts()}]`, formatMessage(args)),
+	info: (...args: unknown[]) => getChannel().info(formatMessage(args)),
+	warn: (...args: unknown[]) => getChannel().warn(formatMessage(args)),
+	error: (...args: unknown[]) => getChannel().error(formatMessage(args)),
+	debug: (...args: unknown[]) => getChannel().debug(formatMessage(args)),
 	show: () => getChannel().show(),
 	dispose: () => {
 		channel?.dispose();

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,10 +1,10 @@
 import vscode from 'vscode';
 
-let channel: vscode.OutputChannel | undefined;
+let channel: vscode.LogOutputChannel | undefined;
 
-function getChannel(): vscode.OutputChannel {
+function getChannel(): vscode.LogOutputChannel {
 	if (!channel) {
-		channel = vscode.window.createOutputChannel('DeepSeek');
+		channel = vscode.window.createOutputChannel('DeepSeek', { log: true });
 	}
 	return channel;
 }
@@ -13,8 +13,8 @@ function ts(): string {
 	return new Date().toISOString().slice(11, 23);
 }
 
-function write(level: string, args: unknown[]): void {
-	const text = args
+function formatMessage(args: unknown[]): string {
+	return args
 		.map((a) => {
 			if (typeof a === 'string') return a;
 			if (a instanceof Error) return a.stack ?? a.message;
@@ -25,14 +25,13 @@ function write(level: string, args: unknown[]): void {
 			}
 		})
 		.join(' ');
-	getChannel().appendLine(`[${ts()}] [${level}] ${text}`);
 }
 
 export const logger = {
-	info: (...args: unknown[]) => write('info', args),
-	warn: (...args: unknown[]) => write('warn', args),
-	error: (...args: unknown[]) => write('error', args),
-	debug: (...args: unknown[]) => write('debug', args),
+	info: (...args: unknown[]) => getChannel().info(`[${ts()}]`, formatMessage(args)),
+	warn: (...args: unknown[]) => getChannel().warn(`[${ts()}]`, formatMessage(args)),
+	error: (...args: unknown[]) => getChannel().error(`[${ts()}]`, formatMessage(args)),
+	debug: (...args: unknown[]) => getChannel().debug(`[${ts()}]`, formatMessage(args)),
 	show: () => getChannel().show(),
 	dispose: () => {
 		channel?.dispose();

--- a/src/provider/diagnostics.ts
+++ b/src/provider/diagnostics.ts
@@ -280,8 +280,8 @@ class DefaultCacheDiagnosticsRecorder implements CacheDiagnosticsRecorder {
 			options.visionModelId,
 		);
 
-		logger.info(`[cache-trace #${requestId}] ${formatCacheTraceSnapshot(cacheTrace)}`);
-		logger.info(
+		logger.debug(`[cache-trace #${requestId}] ${formatCacheTraceSnapshot(cacheTrace)}`);
+		logger.debug(
 			`[cache-trace #${requestId}] request vscodeModel=${options.vscodeModelId}` +
 				formatSegmentTrace(options.segment) +
 				` apiModel=${options.request.model}` +
@@ -294,32 +294,32 @@ class DefaultCacheDiagnosticsRecorder implements CacheDiagnosticsRecorder {
 		);
 		const hostPromptTrace = summarizeHostPromptTrace(options.inputMessages);
 		if (shouldLogHostPromptTrace(hostPromptTrace)) {
-			logger.info(`[cache-trace #${requestId}] ${formatHostPromptTrace(hostPromptTrace)}`);
+			logger.debug(`[cache-trace #${requestId}] ${formatHostPromptTrace(hostPromptTrace)}`);
 		}
 		const vscodeMessageTrace = formatVscodeMessageTrace(options.inputMessages);
 		if (vscodeMessageTrace) {
-			logger.info(`[cache-trace #${requestId}] vscodeMsgs ${vscodeMessageTrace}`);
+			logger.debug(`[cache-trace #${requestId}] vscodeMsgs ${vscodeMessageTrace}`);
 		}
 		for (const detailLine of formatCacheTraceDetailLines(cacheTrace)) {
-			logger.info(`[cache-trace #${requestId}] ${detailLine}`);
+			logger.debug(`[cache-trace #${requestId}] ${detailLine}`);
 		}
 		const visionTrace = formatVisionTrace(visionResolution, options.visionStats);
 		if (visionTrace) {
-			logger.info(`[cache-trace #${requestId}] ${visionTrace}`);
+			logger.debug(`[cache-trace #${requestId}] ${visionTrace}`);
 		}
 		if (cacheTraceComparison) {
-			logger.info(
+			logger.debug(
 				`[cache-trace #${requestId}] ${formatCacheTraceComparison(cacheTraceComparison)}`,
 			);
 			for (const detailLine of formatCacheTraceComparisonDetailLines(cacheTraceComparison)) {
-				logger.info(`[cache-trace #${requestId}] ${detailLine}`);
+				logger.debug(`[cache-trace #${requestId}] ${detailLine}`);
 			}
 			for (const warning of getCacheTraceComparisonWarnings(cacheTraceComparison)) {
 				logger.warn(`[cache-trace #${requestId}] ${warning}`);
 			}
 		}
 		if (traceKeyChangeComparison && previousImmediateCacheTrace) {
-			logger.info(
+			logger.debug(
 				`[cache-trace #${requestId}] ${formatCacheTraceKeyChangeComparison(
 					previousImmediateCacheTrace.cacheTraceKey,
 					cacheTrace.cacheTraceKey,
@@ -327,7 +327,7 @@ class DefaultCacheDiagnosticsRecorder implements CacheDiagnosticsRecorder {
 				)}`,
 			);
 			for (const detailLine of formatCacheTraceComparisonDetailLines(traceKeyChangeComparison)) {
-				logger.info(`[cache-trace #${requestId}] cacheTraceKeyChanged ${detailLine}`);
+				logger.debug(`[cache-trace #${requestId}] cacheTraceKeyChanged ${detailLine}`);
 			}
 			for (const warning of getCacheTraceComparisonWarnings(traceKeyChangeComparison)) {
 				logger.warn(`[cache-trace #${requestId}] cacheTraceKeyChanged fallback diff: ${warning}`);
@@ -337,7 +337,7 @@ class DefaultCacheDiagnosticsRecorder implements CacheDiagnosticsRecorder {
 			logger.warn(`[cache-trace #${requestId}] ${warning}`);
 		}
 		for (const infoLine of getCacheTraceInfoLines(cacheTrace)) {
-			logger.info(`[cache-trace #${requestId}] ${infoLine}`);
+			logger.debug(`[cache-trace #${requestId}] ${infoLine}`);
 		}
 
 		return new ActiveCacheDiagnosticsRun(
@@ -382,7 +382,7 @@ class ActiveCacheDiagnosticsRun implements CacheDiagnosticsRun {
 
 	onDone(info: CacheDiagnosticsDoneInfo): void {
 		if (info.emittedToolCalls > 0 || info.trailingToolResults > 0) {
-			logger.info(
+			logger.debug(
 				`[cache-trace #${this.requestId}] stream done reasoningTextChars=${info.reasoningTextChars}` +
 					` emittedToolCalls=${info.emittedToolCalls}` +
 					` trailingToolResults=${info.trailingToolResults}`,
@@ -395,7 +395,7 @@ class ActiveCacheDiagnosticsRun implements CacheDiagnosticsRun {
 		logUsage(usage, charsPerToken, this.requestId);
 		if (this.resultComparison) {
 			const hitRate = getCacheHitRate(usage);
-			logger.info(
+			logger.debug(
 				`[cache-trace #${this.requestId}] result cacheRate=${hitRate}%` +
 					` ${this.prefixLabel}=${this.resultComparison.commonPrefixSummaryChars}` +
 					` chars (${this.resultComparison.commonPrefixSummaryPercent.toFixed(1)}%)`,
@@ -408,11 +408,11 @@ class ActiveCacheDiagnosticsRun implements CacheDiagnosticsRun {
 			return;
 		}
 		this.cancellationLogged = true;
-		logger.info(`[cache-trace #${this.requestId}] cancellation token requested; aborting stream`);
+		logger.debug(`[cache-trace #${this.requestId}] cancellation token requested; aborting stream`);
 	}
 
 	onReplayMarkerReport(info: ReplayMarkerReportInfo): void {
-		logger.info(`[cache-trace #${this.requestId}] ${formatReplayMarkerReport(info)}`);
+		logger.debug(`[cache-trace #${this.requestId}] ${formatReplayMarkerReport(info)}`);
 	}
 }
 

--- a/src/provider/diagnostics.ts
+++ b/src/provider/diagnostics.ts
@@ -227,14 +227,14 @@ export function createCacheDiagnosticsRecorder(): CacheDiagnosticsRecorder {
 
 export function logToolFlowDiagnostics({
 	tools,
-	filteredProviderMessages,
+	messagesFiltered,
 	preflight,
 	activatePreflight,
 	nextRound,
 	initialResponseNotice,
 }: {
 	tools: readonly vscode.LanguageModelChatTool[] | undefined;
-	filteredProviderMessages: boolean;
+	messagesFiltered: boolean;
 	preflight: 'skipped' | 'handled' | 'ready' | 'round-limit';
 	activatePreflight?: ActivatePreflightInspection;
 	nextRound?: number;
@@ -249,7 +249,7 @@ export function logToolFlowDiagnostics({
 			(count, tool) => count + (tool.name.startsWith(ACTIVATE_TOOL_PREFIX) ? 1 : 0),
 			0,
 		) ?? 0;
-	if (preflight === 'skipped' && !filteredProviderMessages && activateToolCount === 0) {
+	if (preflight === 'skipped' && !messagesFiltered && activateToolCount === 0) {
 		return;
 	}
 
@@ -257,8 +257,8 @@ export function logToolFlowDiagnostics({
 		`[tool-flow] preflight=${preflight}` +
 		` tools=${tools?.length ?? 0}` +
 		` activateTools=${activateToolCount}`;
-	if (filteredProviderMessages) {
-		message += ` filteredProviderMessages=true`;
+	if (messagesFiltered) {
+		message += ` messagesFiltered=true`;
 	}
 	if (activatePreflight) {
 		message +=

--- a/src/provider/diagnostics.ts
+++ b/src/provider/diagnostics.ts
@@ -6,6 +6,8 @@ import { logger } from '../logger';
 import type { DeepSeekMessage, DeepSeekRequest, DeepSeekTool, DeepSeekUsage } from '../types';
 import { REPLAY_MARKER_MIME, parseFirstReplayMarker } from './replay';
 import type { ConversationSegment } from './segment';
+import { ACTIVATE_TOOL_PREFIX } from './tools/consts';
+import type { ActivatePreflightInspection } from './tools/preflight';
 import { IMAGE_DESCRIPTION_UNAVAILABLE } from './vision/consts';
 import type { VisionResolutionStats as VisionPipelineStats } from './vision/index';
 
@@ -223,6 +225,57 @@ export function createCacheDiagnosticsRecorder(): CacheDiagnosticsRecorder {
 	return new DefaultCacheDiagnosticsRecorder();
 }
 
+export function logToolFlowDiagnostics({
+	tools,
+	filteredProviderMessages,
+	preflight,
+	activatePreflight,
+	nextRound,
+	initialResponseNotice,
+}: {
+	tools: readonly vscode.LanguageModelChatTool[] | undefined;
+	filteredProviderMessages: boolean;
+	preflight: 'skipped' | 'handled' | 'ready' | 'round-limit';
+	activatePreflight?: ActivatePreflightInspection;
+	nextRound?: number;
+	initialResponseNotice?: boolean;
+}): void {
+	if (!getDebugLoggingEnabled()) {
+		return;
+	}
+
+	const activateToolCount =
+		tools?.reduce(
+			(count, tool) => count + (tool.name.startsWith(ACTIVATE_TOOL_PREFIX) ? 1 : 0),
+			0,
+		) ?? 0;
+	if (preflight === 'skipped' && !filteredProviderMessages && activateToolCount === 0) {
+		return;
+	}
+
+	let message =
+		`[tool-flow] preflight=${preflight}` +
+		` tools=${tools?.length ?? 0}` +
+		` activateTools=${activateToolCount}`;
+	if (filteredProviderMessages) {
+		message += ` filteredProviderMessages=true`;
+	}
+	if (activatePreflight) {
+		message +=
+			` preflightRounds=${activatePreflight.rounds}` +
+			` calledActivators=${activatePreflight.calledActivatorNames.length}` +
+			` remainingActivators=${activatePreflight.remainingActivatorNames.length}`;
+	}
+	if (nextRound !== undefined) {
+		message += ` nextRound=${nextRound}`;
+	}
+	if (initialResponseNotice) {
+		message += ` initialResponseNotice=true`;
+	}
+
+	logger.info(message);
+}
+
 interface VisionMessageStats {
 	inputImageParts: number;
 	inputImageMessages: number;
@@ -280,46 +333,50 @@ class DefaultCacheDiagnosticsRecorder implements CacheDiagnosticsRecorder {
 			options.visionModelId,
 		);
 
-		logger.debug(`[cache-trace #${requestId}] ${formatCacheTraceSnapshot(cacheTrace)}`);
-		logger.debug(
+		logger.info(`[cache-trace #${requestId}] ${formatCacheTraceSnapshot(cacheTrace)}`);
+		logger.info(
 			`[cache-trace #${requestId}] request vscodeModel=${options.vscodeModelId}` +
 				formatSegmentTrace(options.segment) +
 				` apiModel=${options.request.model}` +
 				` thinking=${options.isThinkingModel}` +
 				` thinkingEffort=${options.thinkingEffort}` +
 				` maxTokens=${options.maxTokens ?? 'api-default'}` +
-				` replayMarker=message-local` +
 				` inputMessages=${options.inputMessages.length}` +
 				` deepseekMessages=${options.request.messages.length}`,
 		);
 		const hostPromptTrace = summarizeHostPromptTrace(options.inputMessages);
 		if (shouldLogHostPromptTrace(hostPromptTrace)) {
-			logger.debug(`[cache-trace #${requestId}] ${formatHostPromptTrace(hostPromptTrace)}`);
+			logger.info(`[cache-trace #${requestId}] ${formatHostPromptTrace(hostPromptTrace)}`);
 		}
 		const vscodeMessageTrace = formatVscodeMessageTrace(options.inputMessages);
 		if (vscodeMessageTrace) {
 			logger.debug(`[cache-trace #${requestId}] vscodeMsgs ${vscodeMessageTrace}`);
 		}
 		for (const detailLine of formatCacheTraceDetailLines(cacheTrace)) {
-			logger.debug(`[cache-trace #${requestId}] ${detailLine}`);
+			const message = `[cache-trace #${requestId}] ${detailLine}`;
+			if (detailLine.startsWith('contentMarkers ')) {
+				logger.debug(message);
+			} else {
+				logger.info(message);
+			}
 		}
 		const visionTrace = formatVisionTrace(visionResolution, options.visionStats);
 		if (visionTrace) {
-			logger.debug(`[cache-trace #${requestId}] ${visionTrace}`);
+			logger.info(`[cache-trace #${requestId}] ${visionTrace}`);
 		}
 		if (cacheTraceComparison) {
-			logger.debug(
+			logger.info(
 				`[cache-trace #${requestId}] ${formatCacheTraceComparison(cacheTraceComparison)}`,
 			);
 			for (const detailLine of formatCacheTraceComparisonDetailLines(cacheTraceComparison)) {
-				logger.debug(`[cache-trace #${requestId}] ${detailLine}`);
+				logger.info(`[cache-trace #${requestId}] ${detailLine}`);
 			}
 			for (const warning of getCacheTraceComparisonWarnings(cacheTraceComparison)) {
 				logger.warn(`[cache-trace #${requestId}] ${warning}`);
 			}
 		}
 		if (traceKeyChangeComparison && previousImmediateCacheTrace) {
-			logger.debug(
+			logger.info(
 				`[cache-trace #${requestId}] ${formatCacheTraceKeyChangeComparison(
 					previousImmediateCacheTrace.cacheTraceKey,
 					cacheTrace.cacheTraceKey,
@@ -327,7 +384,7 @@ class DefaultCacheDiagnosticsRecorder implements CacheDiagnosticsRecorder {
 				)}`,
 			);
 			for (const detailLine of formatCacheTraceComparisonDetailLines(traceKeyChangeComparison)) {
-				logger.debug(`[cache-trace #${requestId}] cacheTraceKeyChanged ${detailLine}`);
+				logger.info(`[cache-trace #${requestId}] cacheTraceKeyChanged ${detailLine}`);
 			}
 			for (const warning of getCacheTraceComparisonWarnings(traceKeyChangeComparison)) {
 				logger.warn(`[cache-trace #${requestId}] cacheTraceKeyChanged fallback diff: ${warning}`);
@@ -337,7 +394,7 @@ class DefaultCacheDiagnosticsRecorder implements CacheDiagnosticsRecorder {
 			logger.warn(`[cache-trace #${requestId}] ${warning}`);
 		}
 		for (const infoLine of getCacheTraceInfoLines(cacheTrace)) {
-			logger.debug(`[cache-trace #${requestId}] ${infoLine}`);
+			logger.info(`[cache-trace #${requestId}] ${infoLine}`);
 		}
 
 		return new ActiveCacheDiagnosticsRun(
@@ -382,7 +439,7 @@ class ActiveCacheDiagnosticsRun implements CacheDiagnosticsRun {
 
 	onDone(info: CacheDiagnosticsDoneInfo): void {
 		if (info.emittedToolCalls > 0 || info.trailingToolResults > 0) {
-			logger.debug(
+			logger.info(
 				`[cache-trace #${this.requestId}] stream done reasoningTextChars=${info.reasoningTextChars}` +
 					` emittedToolCalls=${info.emittedToolCalls}` +
 					` trailingToolResults=${info.trailingToolResults}`,
@@ -395,7 +452,7 @@ class ActiveCacheDiagnosticsRun implements CacheDiagnosticsRun {
 		logUsage(usage, charsPerToken, this.requestId);
 		if (this.resultComparison) {
 			const hitRate = getCacheHitRate(usage);
-			logger.debug(
+			logger.info(
 				`[cache-trace #${this.requestId}] result cacheRate=${hitRate}%` +
 					` ${this.prefixLabel}=${this.resultComparison.commonPrefixSummaryChars}` +
 					` chars (${this.resultComparison.commonPrefixSummaryPercent.toFixed(1)}%)`,
@@ -408,11 +465,11 @@ class ActiveCacheDiagnosticsRun implements CacheDiagnosticsRun {
 			return;
 		}
 		this.cancellationLogged = true;
-		logger.debug(`[cache-trace #${this.requestId}] cancellation token requested; aborting stream`);
+		logger.info(`[cache-trace #${this.requestId}] cancellation token requested; aborting stream`);
 	}
 
 	onReplayMarkerReport(info: ReplayMarkerReportInfo): void {
-		logger.debug(`[cache-trace #${this.requestId}] ${formatReplayMarkerReport(info)}`);
+		logger.info(`[cache-trace #${this.requestId}] ${formatReplayMarkerReport(info)}`);
 	}
 }
 

--- a/src/provider/dump.ts
+++ b/src/provider/dump.ts
@@ -915,7 +915,7 @@ function logProviderInputDump(
 	const systemPromptSummary = summarizeVscodeSystemPrompt(options.messages);
 	logger.info(
 		`providerInputDump written: ${formatDumpSegment(options.segment)}` +
-			` input=${paths.providerInput} ` +
+			` input=file://${paths.providerInput} ` +
 			`(${options.messages.length} msgs, ${toolSummary.toolCount} tools, ` +
 			`activateTools=${toolSummary.activateToolCount}${formatActivateToolNames(
 				toolSummary.activateToolNames,
@@ -934,8 +934,8 @@ function logRequestDump(
 	const systemPromptSummary = summarizeDeepSeekSystemPrompt(request.messages);
 	logger.info(
 		`requestDump written: ${formatDumpSegment(options.segment)}` +
-			` request=${paths.request} ` +
-			`input=${paths.input} resolved=${paths.resolved} ` +
+			` request=file://${paths.request} ` +
+			`input=file://${paths.input} resolved=file://${paths.resolved} ` +
 			`(${request.messages.length} msgs, ${request.tools?.length ?? 0} tools, ` +
 			`~${(requestJsonLength / 1024).toFixed(0)} KB) ` +
 			formatHostSettingsSummary(summarizeHostSettings()) +

--- a/src/provider/dump.ts
+++ b/src/provider/dump.ts
@@ -917,7 +917,7 @@ function logProviderInputDump(
 	toolSummary: ToolSummary,
 ): void {
 	const systemPromptSummary = summarizeVscodeSystemPrompt(options.messages);
-	logger.info(
+	logger.debug(
 		`providerInputDump written: ${formatDumpSegment(options.segment)}` +
 			` input=file://${encodeFilePath(paths.providerInput)} ` +
 			`(${options.messages.length} msgs, ${toolSummary.toolCount} tools, ` +
@@ -936,7 +936,7 @@ function logRequestDump(
 	requestJsonLength: number,
 ): void {
 	const systemPromptSummary = summarizeDeepSeekSystemPrompt(request.messages);
-	logger.info(
+	logger.debug(
 		`requestDump written: ${formatDumpSegment(options.segment)}` +
 			` request=file://${encodeFilePath(paths.request)} ` +
 			`input=file://${encodeFilePath(paths.input)} resolved=file://${encodeFilePath(paths.resolved)} ` +

--- a/src/provider/dump.ts
+++ b/src/provider/dump.ts
@@ -907,6 +907,10 @@ function enqueueDumpWrite(label: string, write: () => Promise<void>): void {
 	});
 }
 
+function encodeFilePath(fsPath: string): string {
+	return fsPath.split('/').map(encodeURIComponent).join('/');
+}
+
 function logProviderInputDump(
 	options: DumpProviderInputOptions,
 	paths: ProviderInputDumpPaths,
@@ -915,7 +919,7 @@ function logProviderInputDump(
 	const systemPromptSummary = summarizeVscodeSystemPrompt(options.messages);
 	logger.info(
 		`providerInputDump written: ${formatDumpSegment(options.segment)}` +
-			` input=file://${paths.providerInput} ` +
+			` input=file://${encodeFilePath(paths.providerInput)} ` +
 			`(${options.messages.length} msgs, ${toolSummary.toolCount} tools, ` +
 			`activateTools=${toolSummary.activateToolCount}${formatActivateToolNames(
 				toolSummary.activateToolNames,
@@ -934,8 +938,8 @@ function logRequestDump(
 	const systemPromptSummary = summarizeDeepSeekSystemPrompt(request.messages);
 	logger.info(
 		`requestDump written: ${formatDumpSegment(options.segment)}` +
-			` request=file://${paths.request} ` +
-			`input=file://${paths.input} resolved=file://${paths.resolved} ` +
+			` request=file://${encodeFilePath(paths.request)} ` +
+			`input=file://${encodeFilePath(paths.input)} resolved=file://${encodeFilePath(paths.resolved)} ` +
 			`(${request.messages.length} msgs, ${request.tools?.length ?? 0} tools, ` +
 			`~${(requestJsonLength / 1024).toFixed(0)} KB) ` +
 			formatHostSettingsSummary(summarizeHostSettings()) +

--- a/src/provider/dump.ts
+++ b/src/provider/dump.ts
@@ -907,8 +907,8 @@ function enqueueDumpWrite(label: string, write: () => Promise<void>): void {
 	});
 }
 
-function encodeFilePath(fsPath: string): string {
-	return fsPath.split('/').map(encodeURIComponent).join('/');
+function formatFileUri(fsPath: string): string {
+	return vscode.Uri.file(fsPath).toString();
 }
 
 function logProviderInputDump(
@@ -919,7 +919,7 @@ function logProviderInputDump(
 	const systemPromptSummary = summarizeVscodeSystemPrompt(options.messages);
 	logger.debug(
 		`providerInputDump written: ${formatDumpSegment(options.segment)}` +
-			` input=file://${encodeFilePath(paths.providerInput)} ` +
+			` input=${formatFileUri(paths.providerInput)} ` +
 			`(${options.messages.length} msgs, ${toolSummary.toolCount} tools, ` +
 			`activateTools=${toolSummary.activateToolCount}${formatActivateToolNames(
 				toolSummary.activateToolNames,
@@ -938,8 +938,8 @@ function logRequestDump(
 	const systemPromptSummary = summarizeDeepSeekSystemPrompt(request.messages);
 	logger.debug(
 		`requestDump written: ${formatDumpSegment(options.segment)}` +
-			` request=file://${encodeFilePath(paths.request)} ` +
-			`input=file://${encodeFilePath(paths.input)} resolved=file://${encodeFilePath(paths.resolved)} ` +
+			` request=${formatFileUri(paths.request)} ` +
+			`input=${formatFileUri(paths.input)} resolved=${formatFileUri(paths.resolved)} ` +
 			`(${request.messages.length} msgs, ${request.tools?.length ?? 0} tools, ` +
 			`~${(requestJsonLength / 1024).toFixed(0)} KB) ` +
 			formatHostSettingsSummary(summarizeHostSettings()) +

--- a/src/provider/tools/flow.ts
+++ b/src/provider/tools/flow.ts
@@ -1,5 +1,6 @@
 import vscode from 'vscode';
 import { t } from '../../i18n';
+import { logToolFlowDiagnostics } from '../diagnostics';
 import { ACTIVATE_TOOL_PREFIX, MAX_PREFLIGHT_ROUNDS_PER_USER_REQUEST } from './consts';
 import { createToolDriftNotice, filterProviderNotices } from './notices';
 import {
@@ -28,8 +29,14 @@ export function processToolFlow({
 	progress,
 }: ToolFlowOptions): ToolFlowResult {
 	const filteredMessages = filterProviderNotices(filterPreflightControlFlow(messages));
+	const filteredProviderMessages = filteredMessages !== messages;
 
 	if (!stabilizeToolList) {
+		logToolFlowDiagnostics({
+			tools,
+			filteredProviderMessages,
+			preflight: 'skipped',
+		});
 		return {
 			preflightHandled: false,
 			messages: filteredMessages,
@@ -39,12 +46,25 @@ export function processToolFlow({
 	const activatePreflight = inspectActivatePreflight(messages, tools);
 	if (activatePreflight.remainingActivatorNames.length > 0) {
 		if (activatePreflight.rounds >= MAX_PREFLIGHT_ROUNDS_PER_USER_REQUEST) {
+			logToolFlowDiagnostics({
+				tools,
+				filteredProviderMessages,
+				preflight: 'round-limit',
+				activatePreflight,
+			});
 			throw new Error(
 				t('request.preflightRoundLimitExceeded', MAX_PREFLIGHT_ROUNDS_PER_USER_REQUEST),
 			);
 		}
 
 		const nextRound = activatePreflight.rounds + 1;
+		logToolFlowDiagnostics({
+			tools,
+			filteredProviderMessages,
+			preflight: 'handled',
+			activatePreflight,
+			nextRound,
+		});
 		for (const toolName of activatePreflight.remainingActivatorNames) {
 			progress.report(
 				new vscode.LanguageModelToolCallPart(
@@ -61,6 +81,13 @@ export function processToolFlow({
 	const hasUnexpandedActivateTools =
 		activatePreflight.rounds > 0 &&
 		tools?.some((tool) => tool.name.startsWith(ACTIVATE_TOOL_PREFIX));
+	logToolFlowDiagnostics({
+		tools,
+		filteredProviderMessages,
+		preflight: 'ready',
+		activatePreflight,
+		initialResponseNotice: hasUnexpandedActivateTools,
+	});
 
 	return {
 		preflightHandled: false,

--- a/src/provider/tools/flow.ts
+++ b/src/provider/tools/flow.ts
@@ -29,12 +29,12 @@ export function processToolFlow({
 	progress,
 }: ToolFlowOptions): ToolFlowResult {
 	const filteredMessages = filterProviderNotices(filterPreflightControlFlow(messages));
-	const filteredProviderMessages = filteredMessages !== messages;
+	const messagesFiltered = filteredMessages !== messages;
 
 	if (!stabilizeToolList) {
 		logToolFlowDiagnostics({
 			tools,
-			filteredProviderMessages,
+			messagesFiltered,
 			preflight: 'skipped',
 		});
 		return {
@@ -48,7 +48,7 @@ export function processToolFlow({
 		if (activatePreflight.rounds >= MAX_PREFLIGHT_ROUNDS_PER_USER_REQUEST) {
 			logToolFlowDiagnostics({
 				tools,
-				filteredProviderMessages,
+				messagesFiltered,
 				preflight: 'round-limit',
 				activatePreflight,
 			});
@@ -60,7 +60,7 @@ export function processToolFlow({
 		const nextRound = activatePreflight.rounds + 1;
 		logToolFlowDiagnostics({
 			tools,
-			filteredProviderMessages,
+			messagesFiltered,
 			preflight: 'handled',
 			activatePreflight,
 			nextRound,
@@ -83,7 +83,7 @@ export function processToolFlow({
 		tools?.some((tool) => tool.name.startsWith(ACTIVATE_TOOL_PREFIX));
 	logToolFlowDiagnostics({
 		tools,
-		filteredProviderMessages,
+		messagesFiltered,
 		preflight: 'ready',
 		activatePreflight,
 		initialResponseNotice: hasUnexpandedActivateTools,


### PR DESCRIPTION
## Summary
- show privacy-safe metadata diagnostics at the default visible log level
- keep verbose dump file-path logs at debug level
- add focused tool-flow diagnostics for tool activation/preflight states

## Verification
- npm run compile
- npm run lint
- npm run format:check