### PR TITLE
Fix cache diagnostics request classification

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,7 +4,7 @@ import { CONFIG_SECTION, WALKTHROUGH_ID, WELCOME_SHOWN_KEY } from './consts';
 import { t } from './i18n';
 import { logger } from './logger';
 import { DeepSeekChatProvider } from './provider';
-import { ensureRequestDumpRoot } from './provider/dump';
+import { ensureRequestDumpRoot } from './provider/debug';
 
 let activeProvider: DeepSeekChatProvider | undefined;
 

--- a/src/provider/debug/classifier.ts
+++ b/src/provider/debug/classifier.ts
@@ -1,0 +1,132 @@
+import vscode from 'vscode';
+import type { DeepSeekRequest, DeepSeekTool } from '../../types';
+
+export type RequestKind =
+	| 'main-agent'
+	| 'terminal-steering'
+	| 'todo-tracker'
+	| 'settings-resolver'
+	| 'background'
+	| 'unknown';
+
+const TODO_TRACKER_PREFIX = 'You are a background task tracker';
+const SETTINGS_RESOLVER_PREFIX =
+	'You are a Visual Studio Code assistant. Your job is to assist users in using Visual Studio Code by returning settings';
+const MAIN_AGENT_PREFIX = 'You are an expert AI programming assistant';
+const TERMINAL_NOTIFICATION_PATTERN = /^\[Terminal\s+\S+\s+notification:/;
+
+export function formatModelFields(vscodeModelId: string, apiModelId?: string): string {
+	const apiField = apiModelId && apiModelId !== vscodeModelId ? ` apiModel=${apiModelId}` : '';
+	return `model=${vscodeModelId}${apiField}`;
+}
+
+export function formatRequestLogLine(requestKind: RequestKind, message: string): string {
+	return `[${requestKind}] ${message}`;
+}
+
+export function classifyProviderRequest(input: {
+	messages: readonly vscode.LanguageModelChatRequestMessage[];
+	tools?: readonly vscode.LanguageModelChatTool[];
+}): RequestKind {
+	return classifyRequest({
+		firstText: getFirstVscodeText(input.messages),
+		latestUserText: getLatestVscodeUserText(input.messages),
+		toolNames: input.tools?.map((tool) => tool.name) ?? [],
+	});
+}
+
+export function classifyDeepSeekRequest(input: {
+	request: DeepSeekRequest;
+	inputMessages?: readonly vscode.LanguageModelChatRequestMessage[];
+}): RequestKind {
+	return classifyRequest({
+		firstText:
+			input.request.messages[0]?.content ??
+			(input.inputMessages ? getFirstVscodeText(input.inputMessages) : ''),
+		latestUserText:
+			(input.inputMessages ? getLatestVscodeUserText(input.inputMessages) : '') ||
+			getLatestDeepSeekUserText(input.request),
+		toolNames: input.request.tools?.map(getDeepSeekToolName) ?? [],
+	});
+}
+
+function classifyRequest(input: {
+	firstText: string;
+	latestUserText: string;
+	toolNames: readonly string[];
+}): RequestKind {
+	const firstText = input.firstText.trimStart();
+	const latestUserText = input.latestUserText.trimStart();
+	if (TERMINAL_NOTIFICATION_PATTERN.test(latestUserText)) {
+		return 'terminal-steering';
+	}
+	if (
+		isOnlyTool(input.toolNames, 'manage_todo_list') ||
+		firstText.startsWith(TODO_TRACKER_PREFIX)
+	) {
+		return 'todo-tracker';
+	}
+	if (firstText.startsWith(SETTINGS_RESOLVER_PREFIX)) {
+		return 'settings-resolver';
+	}
+	if (
+		firstText.startsWith(MAIN_AGENT_PREFIX) ||
+		firstText.includes('<skills>') ||
+		firstText.includes('<agents>')
+	) {
+		return 'main-agent';
+	}
+	if (input.toolNames.length > 0 || firstText.length > 0) {
+		return 'background';
+	}
+	return 'unknown';
+}
+
+function isOnlyTool(toolNames: readonly string[], toolName: string): boolean {
+	return toolNames.length === 1 && toolNames[0] === toolName;
+}
+
+function getDeepSeekToolName(tool: DeepSeekTool): string {
+	return tool.function.name;
+}
+
+function getFirstVscodeText(messages: readonly vscode.LanguageModelChatRequestMessage[]): string {
+	const firstMessage = messages[0];
+	if (!firstMessage) {
+		return '';
+	}
+
+	return getVscodeMessageText(firstMessage);
+}
+
+function getLatestVscodeUserText(
+	messages: readonly vscode.LanguageModelChatRequestMessage[],
+): string {
+	for (let index = messages.length - 1; index >= 0; index -= 1) {
+		const message = messages[index];
+		if (message.role === vscode.LanguageModelChatMessageRole.User) {
+			return getVscodeMessageText(message);
+		}
+	}
+	return '';
+}
+
+function getVscodeMessageText(message: vscode.LanguageModelChatRequestMessage): string {
+	let text = '';
+	for (const part of message.content) {
+		if (part instanceof vscode.LanguageModelTextPart) {
+			text += part.value;
+		}
+	}
+	return text;
+}
+
+function getLatestDeepSeekUserText(request: DeepSeekRequest): string {
+	for (let index = request.messages.length - 1; index >= 0; index -= 1) {
+		const message = request.messages[index];
+		if (message.role === 'user') {
+			return message.content;
+		}
+	}
+	return '';
+}

--- a/src/provider/debug/diagnostics.ts
+++ b/src/provider/debug/diagnostics.ts
@@ -1,15 +1,21 @@
 import { createHash } from 'crypto';
 import vscode from 'vscode';
-import { getDebugLoggingEnabled } from '../config';
-import { LANGUAGE_MODEL_CHAT_SYSTEM_ROLE } from '../consts';
-import { logger } from '../logger';
-import type { DeepSeekMessage, DeepSeekRequest, DeepSeekTool, DeepSeekUsage } from '../types';
-import { REPLAY_MARKER_MIME, parseFirstReplayMarker } from './replay';
-import type { ConversationSegment } from './segment';
-import { ACTIVATE_TOOL_PREFIX } from './tools/consts';
-import type { ActivatePreflightInspection } from './tools/preflight';
-import { IMAGE_DESCRIPTION_UNAVAILABLE } from './vision/consts';
-import type { VisionResolutionStats as VisionPipelineStats } from './vision/index';
+import { getDebugLoggingEnabled } from '../../config';
+import { LANGUAGE_MODEL_CHAT_SYSTEM_ROLE } from '../../consts';
+import { logger } from '../../logger';
+import type { DeepSeekMessage, DeepSeekRequest, DeepSeekTool, DeepSeekUsage } from '../../types';
+import { REPLAY_MARKER_MIME, parseFirstReplayMarker } from '../replay';
+import type { ConversationSegment } from '../segment';
+import { ACTIVATE_TOOL_PREFIX } from '../tools/consts';
+import type { ActivatePreflightInspection } from '../tools/preflight';
+import { IMAGE_DESCRIPTION_UNAVAILABLE } from '../vision/consts';
+import type { VisionResolutionStats as VisionPipelineStats } from '../vision/index';
+import {
+	classifyDeepSeekRequest,
+	formatModelFields,
+	formatRequestLogLine,
+	type RequestKind,
+} from './classifier';
 
 const LARGE_MESSAGE_CHARS = 10_000;
 const HASH_WINDOW_CHARS = 2_048;
@@ -112,6 +118,8 @@ export interface CacheTraceContentSectionSummary {
 
 export interface CacheTraceSnapshot {
 	fingerprint: string;
+	requestKind: RequestKind;
+	model: string;
 	cacheTraceKey: string;
 	redactedComparisonInput: string;
 	requiresReasoningContent: boolean;
@@ -158,6 +166,7 @@ export interface CacheTraceSystemPromptChange {
 export interface BeginCacheDiagnosticsOptions {
 	request: DeepSeekRequest;
 	segment: ConversationSegment;
+	requestKind?: RequestKind;
 	vscodeModelId: string;
 	isThinkingModel: boolean;
 	thinkingEffort: string;
@@ -226,6 +235,7 @@ export function createCacheDiagnosticsRecorder(): CacheDiagnosticsRecorder {
 }
 
 export function logToolFlowDiagnostics({
+	requestKind,
 	tools,
 	messagesFiltered,
 	preflight,
@@ -233,6 +243,7 @@ export function logToolFlowDiagnostics({
 	nextRound,
 	initialResponseNotice,
 }: {
+	requestKind: RequestKind;
 	tools: readonly vscode.LanguageModelChatTool[] | undefined;
 	messagesFiltered: boolean;
 	preflight: 'skipped' | 'handled' | 'ready' | 'round-limit';
@@ -273,7 +284,7 @@ export function logToolFlowDiagnostics({
 		message += ` initialResponseNotice=true`;
 	}
 
-	logger.info(message);
+	logger.info(formatRequestLogLine(requestKind, message));
 }
 
 interface VisionMessageStats {
@@ -302,8 +313,15 @@ interface HostPromptTrace {
 	latestUserHasCustomizationsUpdate: boolean;
 }
 
+interface UsageLogContext {
+	vscodeModelId: string;
+	apiModelId: string;
+	requestKind: RequestKind;
+}
+
 class DefaultCacheDiagnosticsRecorder implements CacheDiagnosticsRecorder {
 	private readonly previousCacheTraces = new Map<string, CacheTraceSnapshot>();
+	private readonly lastCacheTracesByScope = new Map<string, CacheTraceSnapshot>();
 	private lastCacheTrace: CacheTraceSnapshot | undefined;
 	private requestId = 0;
 
@@ -312,20 +330,56 @@ class DefaultCacheDiagnosticsRecorder implements CacheDiagnosticsRecorder {
 	}
 
 	beginRequest(options: BeginCacheDiagnosticsOptions): CacheDiagnosticsRun {
+		const requestKind =
+			options.requestKind ??
+			classifyDeepSeekRequest({
+				request: options.request,
+				inputMessages: options.inputMessages,
+			});
+
 		if (!this.isEnabled()) {
 			this.clearCacheTraces();
-			return new NoopCacheDiagnosticsRun();
+			return new NoopCacheDiagnosticsRun({
+				vscodeModelId: options.vscodeModelId,
+				apiModelId: options.request.model,
+				requestKind,
+			});
 		}
 
 		const requestId = (this.requestId += 1);
-		const cacheTrace = createCacheTraceSnapshot(options.request, options.inputMessages);
-		const previousCacheTrace = this.previousCacheTraces.get(cacheTrace.cacheTraceKey);
+		const cacheTrace = createCacheTraceSnapshot(
+			options.request,
+			options.inputMessages,
+			requestKind,
+		);
+		const previousCacheTrace = this.previousCacheTraces.get(getCacheTraceStoreKey(cacheTrace));
 		const previousImmediateCacheTrace = this.lastCacheTrace;
+		const previousScopedCacheTrace = this.lastCacheTracesByScope.get(
+			getCacheTraceScopeKey(cacheTrace),
+		);
 		const cacheTraceComparison = compareCacheTraceSnapshots(previousCacheTrace, cacheTrace);
+		const immediateTraceKeyChanged =
+			previousImmediateCacheTrace?.cacheTraceKey !== undefined &&
+			previousImmediateCacheTrace.cacheTraceKey !== cacheTrace.cacheTraceKey;
+		const sameImmediateComparisonScope =
+			previousImmediateCacheTrace !== undefined &&
+			previousImmediateCacheTrace.requestKind === cacheTrace.requestKind &&
+			previousImmediateCacheTrace.model === cacheTrace.model &&
+			previousImmediateCacheTrace.toolsHash === cacheTrace.toolsHash;
 		const traceKeyChangeComparison =
-			previousImmediateCacheTrace &&
-			previousImmediateCacheTrace.cacheTraceKey !== cacheTrace.cacheTraceKey
+			previousImmediateCacheTrace && immediateTraceKeyChanged && sameImmediateComparisonScope
 				? compareCacheTraceSnapshots(previousImmediateCacheTrace, cacheTrace)
+				: undefined;
+		const skippedImmediateFallback =
+			previousImmediateCacheTrace && immediateTraceKeyChanged && !sameImmediateComparisonScope
+				? previousImmediateCacheTrace
+				: undefined;
+		const scopedTraceKeyChangeComparison =
+			!traceKeyChangeComparison &&
+			previousScopedCacheTrace &&
+			previousScopedCacheTrace !== previousImmediateCacheTrace &&
+			previousScopedCacheTrace.cacheTraceKey !== cacheTrace.cacheTraceKey
+				? compareCacheTraceSnapshots(previousScopedCacheTrace, cacheTrace)
 				: undefined;
 		const visionResolution = summarizeVisionResolution(
 			options.inputMessages,
@@ -333,27 +387,48 @@ class DefaultCacheDiagnosticsRecorder implements CacheDiagnosticsRecorder {
 			options.visionModelId,
 		);
 
-		logger.info(`[cache-trace #${requestId}] ${formatCacheTraceSnapshot(cacheTrace)}`);
 		logger.info(
-			`[cache-trace #${requestId}] request vscodeModel=${options.vscodeModelId}` +
-				formatSegmentTrace(options.segment) +
-				` apiModel=${options.request.model}` +
-				` thinking=${options.isThinkingModel}` +
-				` thinkingEffort=${options.thinkingEffort}` +
-				` maxTokens=${options.maxTokens ?? 'api-default'}` +
-				` inputMessages=${options.inputMessages.length}` +
-				` deepseekMessages=${options.request.messages.length}`,
+			formatRequestLogLine(
+				requestKind,
+				`[cache-trace #${requestId}] ${formatCacheTraceSnapshot(cacheTrace)}`,
+			),
+		);
+		logger.info(
+			formatRequestLogLine(
+				requestKind,
+				`[cache-trace #${requestId}] request ` +
+					formatModelFields(options.vscodeModelId, options.request.model) +
+					formatSegmentTrace(options.segment) +
+					` thinking=${options.isThinkingModel}` +
+					` thinkingEffort=${options.thinkingEffort}` +
+					` maxTokens=${options.maxTokens ?? 'api-default'}` +
+					` inputMessages=${options.inputMessages.length}` +
+					` deepseekMessages=${options.request.messages.length}`,
+			),
 		);
 		const hostPromptTrace = summarizeHostPromptTrace(options.inputMessages);
 		if (shouldLogHostPromptTrace(hostPromptTrace)) {
-			logger.info(`[cache-trace #${requestId}] ${formatHostPromptTrace(hostPromptTrace)}`);
+			logger.info(
+				formatRequestLogLine(
+					requestKind,
+					`[cache-trace #${requestId}] ${formatHostPromptTrace(hostPromptTrace)}`,
+				),
+			);
 		}
 		const vscodeMessageTrace = formatVscodeMessageTrace(options.inputMessages);
 		if (vscodeMessageTrace) {
-			logger.debug(`[cache-trace #${requestId}] vscodeMsgs ${vscodeMessageTrace}`);
+			logger.debug(
+				formatRequestLogLine(
+					requestKind,
+					`[cache-trace #${requestId}] vscodeMsgs ${vscodeMessageTrace}`,
+				),
+			);
 		}
 		for (const detailLine of formatCacheTraceDetailLines(cacheTrace)) {
-			const message = `[cache-trace #${requestId}] ${detailLine}`;
+			const message = formatRequestLogLine(
+				requestKind,
+				`[cache-trace #${requestId}] ${detailLine}`,
+			);
 			if (detailLine.startsWith('contentMarkers ')) {
 				logger.debug(message);
 			} else {
@@ -362,59 +437,139 @@ class DefaultCacheDiagnosticsRecorder implements CacheDiagnosticsRecorder {
 		}
 		const visionTrace = formatVisionTrace(visionResolution, options.visionStats);
 		if (visionTrace) {
-			logger.info(`[cache-trace #${requestId}] ${visionTrace}`);
+			logger.info(formatRequestLogLine(requestKind, `[cache-trace #${requestId}] ${visionTrace}`));
 		}
 		if (cacheTraceComparison) {
 			logger.info(
-				`[cache-trace #${requestId}] ${formatCacheTraceComparison(cacheTraceComparison)}`,
+				formatRequestLogLine(
+					requestKind,
+					`[cache-trace #${requestId}] ${formatCacheTraceComparison(cacheTraceComparison)}`,
+				),
 			);
 			for (const detailLine of formatCacheTraceComparisonDetailLines(cacheTraceComparison)) {
-				logger.info(`[cache-trace #${requestId}] ${detailLine}`);
+				logger.info(formatRequestLogLine(requestKind, `[cache-trace #${requestId}] ${detailLine}`));
 			}
 			for (const warning of getCacheTraceComparisonWarnings(cacheTraceComparison)) {
-				logger.warn(`[cache-trace #${requestId}] ${warning}`);
+				logger.warn(formatRequestLogLine(requestKind, `[cache-trace #${requestId}] ${warning}`));
 			}
 		}
 		if (traceKeyChangeComparison && previousImmediateCacheTrace) {
 			logger.info(
-				`[cache-trace #${requestId}] ${formatCacheTraceKeyChangeComparison(
-					previousImmediateCacheTrace.cacheTraceKey,
-					cacheTrace.cacheTraceKey,
-					traceKeyChangeComparison,
-				)}`,
+				formatRequestLogLine(
+					requestKind,
+					`[cache-trace #${requestId}] ${formatCacheTraceKeyChangeComparison(
+						previousImmediateCacheTrace.cacheTraceKey,
+						cacheTrace.cacheTraceKey,
+						traceKeyChangeComparison,
+					)}`,
+				),
 			);
 			for (const detailLine of formatCacheTraceComparisonDetailLines(traceKeyChangeComparison)) {
-				logger.info(`[cache-trace #${requestId}] cacheTraceKeyChanged ${detailLine}`);
+				logger.info(
+					formatRequestLogLine(
+						requestKind,
+						`[cache-trace #${requestId}] cacheTraceKeyChanged ${detailLine}`,
+					),
+				);
 			}
 			for (const warning of getCacheTraceComparisonWarnings(traceKeyChangeComparison)) {
-				logger.warn(`[cache-trace #${requestId}] cacheTraceKeyChanged fallback diff: ${warning}`);
+				logger.warn(
+					formatRequestLogLine(
+						requestKind,
+						`[cache-trace #${requestId}] cacheTraceKeyChanged fallback diff: ${warning}`,
+					),
+				);
+			}
+		}
+		if (skippedImmediateFallback) {
+			logger.info(
+				formatRequestLogLine(
+					requestKind,
+					`[cache-trace #${requestId}] comparisonScopeChanged` +
+						` prevKind=${skippedImmediateFallback.requestKind}` +
+						` currKind=${cacheTrace.requestKind}` +
+						` prevModel=${skippedImmediateFallback.model}` +
+						` currModel=${cacheTrace.model}` +
+						` toolsChanged=${skippedImmediateFallback.toolsHash !== cacheTrace.toolsHash}` +
+						` cacheTraceKeyChanged=true skipFallbackDiff=true`,
+				),
+			);
+		}
+		if (scopedTraceKeyChangeComparison && previousScopedCacheTrace) {
+			logger.info(
+				formatRequestLogLine(
+					requestKind,
+					`[cache-trace #${requestId}] sameScope ${formatCacheTraceKeyChangeComparison(
+						previousScopedCacheTrace.cacheTraceKey,
+						cacheTrace.cacheTraceKey,
+						scopedTraceKeyChangeComparison,
+					)}`,
+				),
+			);
+			for (const detailLine of formatCacheTraceComparisonDetailLines(
+				scopedTraceKeyChangeComparison,
+			)) {
+				logger.info(
+					formatRequestLogLine(
+						requestKind,
+						`[cache-trace #${requestId}] sameScope cacheTraceKeyChanged ${detailLine}`,
+					),
+				);
+			}
+			for (const warning of getCacheTraceComparisonWarnings(scopedTraceKeyChangeComparison)) {
+				logger.warn(
+					formatRequestLogLine(
+						requestKind,
+						`[cache-trace #${requestId}] sameScope cacheTraceKeyChanged fallback diff: ${warning}`,
+					),
+				);
 			}
 		}
 		for (const warning of getCacheTraceWarnings(cacheTrace)) {
-			logger.warn(`[cache-trace #${requestId}] ${warning}`);
+			logger.warn(formatRequestLogLine(requestKind, `[cache-trace #${requestId}] ${warning}`));
 		}
 		for (const infoLine of getCacheTraceInfoLines(cacheTrace)) {
-			logger.info(`[cache-trace #${requestId}] ${infoLine}`);
+			logger.info(formatRequestLogLine(requestKind, `[cache-trace #${requestId}] ${infoLine}`));
 		}
 
 		return new ActiveCacheDiagnosticsRun(
 			this,
 			requestId,
 			cacheTrace,
-			cacheTraceComparison ?? traceKeyChangeComparison,
-			cacheTraceComparison ? 'summaryPrefixVsPrevious' : 'fallbackSummaryPrefixVsPrevious',
+			{
+				vscodeModelId: options.vscodeModelId,
+				apiModelId: options.request.model,
+				requestKind,
+			},
+			cacheTraceComparison ?? traceKeyChangeComparison ?? scopedTraceKeyChangeComparison,
+			cacheTraceComparison
+				? 'summaryPrefixVsPrevious'
+				: scopedTraceKeyChangeComparison
+					? 'sameScopeFallbackSummaryPrefixVsPrevious'
+					: 'fallbackSummaryPrefixVsPrevious',
 		);
 	}
 
 	private clearCacheTraces(): void {
 		this.lastCacheTrace = undefined;
 		this.previousCacheTraces.clear();
+		this.lastCacheTracesByScope.clear();
 	}
 
 	rememberCacheTrace(snapshot: CacheTraceSnapshot): void {
 		this.lastCacheTrace = snapshot;
-		this.previousCacheTraces.delete(snapshot.cacheTraceKey);
-		this.previousCacheTraces.set(snapshot.cacheTraceKey, snapshot);
+		this.lastCacheTracesByScope.set(getCacheTraceScopeKey(snapshot), snapshot);
+		while (this.lastCacheTracesByScope.size > 50) {
+			const oldestKey = this.lastCacheTracesByScope.keys().next().value;
+			if (!oldestKey) {
+				break;
+			}
+			this.lastCacheTracesByScope.delete(oldestKey);
+		}
+
+		const cacheTraceStoreKey = getCacheTraceStoreKey(snapshot);
+		this.previousCacheTraces.delete(cacheTraceStoreKey);
+		this.previousCacheTraces.set(cacheTraceStoreKey, snapshot);
 
 		while (this.previousCacheTraces.size > 50) {
 			const oldestKey = this.previousCacheTraces.keys().next().value;
@@ -426,6 +581,14 @@ class DefaultCacheDiagnosticsRecorder implements CacheDiagnosticsRecorder {
 	}
 }
 
+function getCacheTraceStoreKey(snapshot: CacheTraceSnapshot): string {
+	return `${snapshot.requestKind}:${snapshot.cacheTraceKey}`;
+}
+
+function getCacheTraceScopeKey(snapshot: CacheTraceSnapshot): string {
+	return `${snapshot.requestKind}:${snapshot.model}:${snapshot.toolsHash}`;
+}
+
 class ActiveCacheDiagnosticsRun implements CacheDiagnosticsRun {
 	private cancellationLogged = false;
 
@@ -433,6 +596,7 @@ class ActiveCacheDiagnosticsRun implements CacheDiagnosticsRun {
 		private readonly recorder: DefaultCacheDiagnosticsRecorder,
 		private readonly requestId: number,
 		private readonly snapshot: CacheTraceSnapshot,
+		private readonly usageLogContext: UsageLogContext,
 		private readonly resultComparison: CacheTraceComparison | undefined,
 		private readonly prefixLabel: string,
 	) {}
@@ -440,22 +604,28 @@ class ActiveCacheDiagnosticsRun implements CacheDiagnosticsRun {
 	onDone(info: CacheDiagnosticsDoneInfo): void {
 		if (info.emittedToolCalls > 0 || info.trailingToolResults > 0) {
 			logger.info(
-				`[cache-trace #${this.requestId}] stream done reasoningTextChars=${info.reasoningTextChars}` +
-					` emittedToolCalls=${info.emittedToolCalls}` +
-					` trailingToolResults=${info.trailingToolResults}`,
+				formatRequestLogLine(
+					this.snapshot.requestKind,
+					`[cache-trace #${this.requestId}] stream done reasoningTextChars=${info.reasoningTextChars}` +
+						` emittedToolCalls=${info.emittedToolCalls}` +
+						` trailingToolResults=${info.trailingToolResults}`,
+				),
 			);
 		}
 		this.recorder.rememberCacheTrace(this.snapshot);
 	}
 
 	onUsage(usage: DeepSeekUsage, charsPerToken: number): void {
-		logUsage(usage, charsPerToken, this.requestId);
+		logUsage(usage, charsPerToken, this.usageLogContext, this.requestId);
 		if (this.resultComparison) {
 			const hitRate = getCacheHitRate(usage);
 			logger.info(
-				`[cache-trace #${this.requestId}] result cacheRate=${hitRate}%` +
-					` ${this.prefixLabel}=${this.resultComparison.commonPrefixSummaryChars}` +
-					` chars (${this.resultComparison.commonPrefixSummaryPercent.toFixed(1)}%)`,
+				formatRequestLogLine(
+					this.snapshot.requestKind,
+					`[cache-trace #${this.requestId}] result cacheRate=${hitRate}%` +
+						` ${this.prefixLabel}=${this.resultComparison.commonPrefixSummaryChars}` +
+						` chars (${this.resultComparison.commonPrefixSummaryPercent.toFixed(1)}%)`,
+				),
 			);
 		}
 	}
@@ -465,15 +635,27 @@ class ActiveCacheDiagnosticsRun implements CacheDiagnosticsRun {
 			return;
 		}
 		this.cancellationLogged = true;
-		logger.info(`[cache-trace #${this.requestId}] cancellation token requested; aborting stream`);
+		logger.info(
+			formatRequestLogLine(
+				this.snapshot.requestKind,
+				`[cache-trace #${this.requestId}] cancellation token requested; aborting stream`,
+			),
+		);
 	}
 
 	onReplayMarkerReport(info: ReplayMarkerReportInfo): void {
-		logger.info(`[cache-trace #${this.requestId}] ${formatReplayMarkerReport(info)}`);
+		logger.info(
+			formatRequestLogLine(
+				this.snapshot.requestKind,
+				`[cache-trace #${this.requestId}] ${formatReplayMarkerReport(info)}`,
+			),
+		);
 	}
 }
 
 class NoopCacheDiagnosticsRun implements CacheDiagnosticsRun {
+	constructor(private readonly usageLogContext: UsageLogContext) {}
+
 	onDone(_info: CacheDiagnosticsDoneInfo): void {}
 
 	onCancellationTokenRequested(): void {}
@@ -481,7 +663,7 @@ class NoopCacheDiagnosticsRun implements CacheDiagnosticsRun {
 	onReplayMarkerReport(_info: ReplayMarkerReportInfo): void {}
 
 	onUsage(usage: DeepSeekUsage, charsPerToken: number): void {
-		logUsage(usage, charsPerToken);
+		logUsage(usage, charsPerToken, this.usageLogContext);
 	}
 }
 
@@ -611,13 +793,23 @@ function sanitizeLogValue(value: string): string {
 	return value.replace(/\s+/g, ' ').slice(0, 200);
 }
 
-function logUsage(usage: DeepSeekUsage, charsPerToken: number, requestId?: number): void {
+function logUsage(
+	usage: DeepSeekUsage,
+	charsPerToken: number,
+	context: UsageLogContext,
+	requestId?: number,
+): void {
 	const cacheHit = usage.prompt_cache_hit_tokens ?? 0;
 	const cacheMiss = usage.prompt_cache_miss_tokens ?? 0;
 	logger.info(
-		`tokens${requestId ? ` #${requestId}` : ''}: prompt=${usage.prompt_tokens} completion=${usage.completion_tokens}` +
-			` | cache: hit=${cacheHit} miss=${cacheMiss} rate=${getCacheHitRate(usage)}%` +
-			` | chars/tok=${charsPerToken.toFixed(2)}`,
+		formatRequestLogLine(
+			context.requestKind,
+			`tokens${requestId ? ` #${requestId}` : ''}: ` +
+				formatModelFields(context.vscodeModelId, context.apiModelId) +
+				` prompt=${usage.prompt_tokens} completion=${usage.completion_tokens}` +
+				` | cache: hit=${cacheHit} miss=${cacheMiss} rate=${getCacheHitRate(usage)}%` +
+				` | chars/tok=${charsPerToken.toFixed(2)}`,
+		),
 	);
 }
 
@@ -953,6 +1145,7 @@ function getPartConstructorName(part: unknown): string {
 export function createCacheTraceSnapshot(
 	request: DeepSeekRequest,
 	inputMessages: readonly vscode.LanguageModelChatRequestMessage[] = [],
+	requestKind: RequestKind = classifyDeepSeekRequest({ request, inputMessages }),
 ): CacheTraceSnapshot {
 	const toolsSerialized = stableStringify(request.tools ?? []);
 	const messageSummaries = summarizeMessages(request.messages);
@@ -966,6 +1159,8 @@ export function createCacheTraceSnapshot(
 
 	return {
 		fingerprint: hashString(redactedComparisonInput),
+		requestKind,
+		model: request.model,
 		cacheTraceKey: hashString(`${request.model}:${firstMessage?.hash ?? 'empty'}`),
 		redactedComparisonInput,
 		requiresReasoningContent: request.thinking?.type === 'enabled',

--- a/src/provider/debug/dump.ts
+++ b/src/provider/debug/dump.ts
@@ -3,15 +3,22 @@ import { appendFile, mkdir, writeFile } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import vscode from 'vscode';
-import { getRequestDumpEnabled } from '../config';
-import { LANGUAGE_MODEL_CHAT_SYSTEM_ROLE } from '../consts';
-import { safeStringify, toWellFormedString } from '../json';
-import { logger } from '../logger';
-import type { DeepSeekMessage, DeepSeekRequest } from '../types';
-import { parseReplayMarkerData, REPLAY_MARKER_MIME } from './replay';
-import type { ConversationSegment } from './segment';
-import { ACTIVATE_TOOL_PREFIX } from './tools/consts';
-import type { VisionResolutionStats } from './vision/index';
+import { getRequestDumpEnabled } from '../../config';
+import { LANGUAGE_MODEL_CHAT_SYSTEM_ROLE } from '../../consts';
+import { safeStringify, toWellFormedString } from '../../json';
+import { logger } from '../../logger';
+import type { DeepSeekMessage, DeepSeekRequest } from '../../types';
+import { parseReplayMarkerData, REPLAY_MARKER_MIME } from '../replay';
+import type { ConversationSegment } from '../segment';
+import { ACTIVATE_TOOL_PREFIX } from '../tools/consts';
+import type { VisionResolutionStats } from '../vision/index';
+import {
+	classifyDeepSeekRequest,
+	classifyProviderRequest,
+	formatModelFields,
+	formatRequestLogLine,
+	type RequestKind,
+} from './classifier';
 
 let dumpCounter = 0;
 let providerInputDumpCounter = 0;
@@ -27,6 +34,7 @@ interface DumpContext {
 	root: string;
 	timestamp: string;
 	basename: string;
+	requestKind: RequestKind;
 }
 
 interface ProviderInputDumpPaths {
@@ -57,7 +65,19 @@ interface CustomizationsSummary {
 
 interface HostSettingsSummary {
 	copilotFreezeCustomizationsIndex: boolean | 'unknown';
+	chatUtilityModel: string | 'unknown';
+	chatUtilitySmallModel: string | 'unknown';
+	chatPlanAgentDefaultModel: string | 'unknown';
+	chatExploreAgentDefaultModel: string | 'unknown';
+	copilotAskAgentModel: string | 'unknown';
+	copilotImplementAgentModel: string | 'unknown';
+	copilotExploreAgentModel: string | 'unknown';
 }
+
+type ProviderRequestOptions = vscode.ProvideLanguageModelChatResponseOptions & {
+	readonly requestInitiator?: unknown;
+	readonly modelConfiguration?: unknown;
+};
 
 interface SystemPromptSummary extends CustomizationsSummary {
 	messageIndex: number | null;
@@ -77,6 +97,7 @@ interface SystemPromptSummary extends CustomizationsSummary {
 export interface DumpDeepSeekRequestOptions {
 	globalStorageUri: vscode.Uri;
 	segment: ConversationSegment;
+	requestKind?: RequestKind;
 	vscodeModelId: string;
 	isThinkingModel: boolean;
 	thinkingEffort: string;
@@ -91,6 +112,7 @@ export interface DumpDeepSeekRequestOptions {
 export interface DumpProviderInputOptions {
 	globalStorageUri: vscode.Uri;
 	segment: ConversationSegment;
+	requestKind?: RequestKind;
 	modelInfo: vscode.LanguageModelChatInformation;
 	messages: readonly vscode.LanguageModelChatRequestMessage[];
 	requestOptions: vscode.ProvideLanguageModelChatResponseOptions;
@@ -104,16 +126,23 @@ export interface DumpProviderInputOptions {
 export function dumpProviderInput(options: DumpProviderInputOptions): void {
 	if (!getRequestDumpEnabled()) return;
 
+	const requestKind =
+		options.requestKind ??
+		classifyProviderRequest({
+			messages: options.messages,
+			tools: options.requestOptions.tools,
+		});
 	const context = createDumpContext(
 		options.globalStorageUri,
 		options.segment,
 		'deepseek-provider-input',
 		(providerInputDumpCounter += 1),
+		requestKind,
 	);
 	const paths = createProviderInputDumpPaths(context);
 	const toolSummary = summarizeTools(options.requestOptions.tools);
 
-	enqueueDumpWrite('providerInputDump', async () => {
+	enqueueDumpWrite(formatRequestLogLine(requestKind, 'providerInputDump'), async () => {
 		await mkdir(context.root, { recursive: true });
 		await writeJsonFile(paths.providerInput, createProviderInputSnapshot(options, context));
 
@@ -127,12 +156,13 @@ export function dumpProviderInput(options: DumpProviderInputOptions): void {
 				model: {
 					vscodeModelId: options.modelInfo.id,
 				},
+				requestKind,
 				requestOptions: options.requestOptions,
 				messages: options.messages,
 				toolSummary,
 			}),
 		);
-		logProviderInputDump(options, paths, toolSummary);
+		logProviderInputDump(options, paths, toolSummary, requestKind);
 	});
 }
 
@@ -154,17 +184,24 @@ export function dumpDeepSeekRequest(
 ): void {
 	if (!getRequestDumpEnabled()) return;
 
+	const requestKind =
+		options.requestKind ??
+		classifyDeepSeekRequest({
+			request,
+			inputMessages: options.inputMessages,
+		});
 	const context = createDumpContext(
 		options.globalStorageUri,
 		options.segment,
 		'deepseek-request',
 		(dumpCounter += 1),
+		requestKind,
 	);
 	const msg0 = request.messages[0];
 	const paths = createRequestDumpPaths(context, Boolean(msg0));
 	const toolSummary = summarizeTools(options.requestOptions.tools);
 
-	enqueueDumpWrite('requestDump', async () => {
+	enqueueDumpWrite(formatRequestLogLine(requestKind, 'requestDump'), async () => {
 		await mkdir(context.root, { recursive: true });
 		await writeJsonFile(
 			paths.input,
@@ -192,14 +229,15 @@ export function dumpDeepSeekRequest(
 				paths,
 				model: {
 					vscodeModelId: options.vscodeModelId,
-					apiModelId: request.model,
+					apiModelId: request.model === options.vscodeModelId ? undefined : request.model,
 				},
+				requestKind,
 				requestOptions: options.requestOptions,
 				messages: options.inputMessages,
 				toolSummary,
 			}),
 		);
-		logRequestDump(request, options, paths, requestJson.length);
+		logRequestDump(request, options, paths, requestJson.length, requestKind);
 	});
 }
 
@@ -214,12 +252,14 @@ function createDumpContext(
 	segment: ConversationSegment,
 	prefix: string,
 	seq: number,
+	requestKind: RequestKind,
 ): DumpContext {
 	const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
 	return {
 		root: getRequestDumpRoot(globalStorageUri, segment),
 		timestamp,
 		basename: `${prefix}-${timestamp}-${String(seq).padStart(4, '0')}`,
+		requestKind,
 	};
 }
 
@@ -246,6 +286,7 @@ function createDumpObservation(options: {
 	segment: ConversationSegment;
 	paths: ProviderInputDumpPaths | RequestDumpPaths;
 	model: object;
+	requestKind: RequestKind;
 	requestOptions: vscode.ProvideLanguageModelChatResponseOptions;
 	messages: readonly vscode.LanguageModelChatRequestMessage[];
 	toolSummary: ToolSummary;
@@ -257,6 +298,7 @@ function createDumpObservation(options: {
 		segment: options.segment,
 		paths: options.paths,
 		model: options.model,
+		requestKind: options.requestKind,
 		options: summarizeRequestOptions(options.requestOptions),
 		hostSettings: summarizeHostSettings(),
 		systemPromptSummary: summarizeVscodeSystemPrompt(options.messages),
@@ -273,6 +315,7 @@ function createProviderInputSnapshot(
 		stage: 'provider-input',
 		context,
 		segment: options.segment,
+		requestKind: context.requestKind,
 		model: {
 			vscodeModelId: options.modelInfo.id,
 			name: options.modelInfo.name,
@@ -298,9 +341,10 @@ function createPipelineSnapshot(
 		stage,
 		context,
 		segment: options.segment,
+		requestKind: context.requestKind,
 		model: {
 			vscodeModelId: options.vscodeModelId,
-			apiModelId: request.model,
+			apiModelId: request.model === options.vscodeModelId ? undefined : request.model,
 			isThinkingModel: options.isThinkingModel,
 			thinkingEffort: options.thinkingEffort,
 			maxTokens: options.maxTokens ?? null,
@@ -322,6 +366,7 @@ function createDumpSnapshot(options: {
 	stage: DumpStage;
 	context: DumpContext;
 	segment: ConversationSegment;
+	requestKind: RequestKind;
 	model: object;
 	vision?: object;
 	deepSeekPromptSummary?: SystemPromptSummary;
@@ -336,6 +381,7 @@ function createDumpSnapshot(options: {
 		timestamp: options.context.timestamp,
 		basename: options.context.basename,
 		segment: options.segment,
+		requestKind: options.requestKind,
 		model: options.model,
 		options: summarizeRequestOptions(options.requestOptions),
 		hostSettings: summarizeHostSettings(),
@@ -702,6 +748,13 @@ function summarizeHostSettings(): HostSettingsSummary {
 			'github.copilot.chat',
 			'freezeCustomizationsIndex',
 		),
+		chatUtilityModel: getStringSetting('chat', 'utilityModel'),
+		chatUtilitySmallModel: getStringSetting('chat', 'utilitySmallModel'),
+		chatPlanAgentDefaultModel: getStringSetting('chat', 'planAgent.defaultModel'),
+		chatExploreAgentDefaultModel: getStringSetting('chat', 'exploreAgent.defaultModel'),
+		copilotAskAgentModel: getStringSetting('github.copilot.chat', 'askAgent.model'),
+		copilotImplementAgentModel: getStringSetting('github.copilot.chat', 'implementAgent.model'),
+		copilotExploreAgentModel: getStringSetting('github.copilot.chat', 'exploreAgent.model'),
 	};
 }
 
@@ -720,6 +773,11 @@ function getBooleanSetting(section: string, key: string): boolean | 'unknown' {
 	return typeof value === 'boolean' ? value : 'unknown';
 }
 
+function getStringSetting(section: string, key: string): string | 'unknown' {
+	const value = vscode.workspace.getConfiguration(section).get<unknown>(key);
+	return typeof value === 'string' ? value : 'unknown';
+}
+
 function summarizeTools(tools: readonly vscode.LanguageModelChatTool[] | undefined): ToolSummary {
 	const toolNames = getToolNames(tools);
 	const activateToolNames = getActivateToolNames(toolNames);
@@ -732,12 +790,17 @@ function summarizeTools(tools: readonly vscode.LanguageModelChatTool[] | undefin
 }
 
 function summarizeRequestOptions(options: vscode.ProvideLanguageModelChatResponseOptions): object {
+	const providerOptions = options as ProviderRequestOptions;
 	const modelOptions = sanitizeJsonValue(options.modelOptions);
+	const modelConfiguration = sanitizeJsonValue(providerOptions.modelConfiguration);
 	return {
 		optionKeys: Object.keys(options).sort(),
+		requestInitiator: sanitizeJsonValue(providerOptions.requestInitiator),
 		toolMode: formatToolMode(options.toolMode),
 		modelOptions,
 		modelOptionsKeys: getObjectKeys(modelOptions),
+		modelConfiguration,
+		modelConfigurationKeys: getObjectKeys(modelConfiguration),
 	};
 }
 
@@ -915,17 +978,22 @@ function logProviderInputDump(
 	options: DumpProviderInputOptions,
 	paths: ProviderInputDumpPaths,
 	toolSummary: ToolSummary,
+	requestKind: RequestKind,
 ): void {
 	const systemPromptSummary = summarizeVscodeSystemPrompt(options.messages);
 	logger.debug(
-		`providerInputDump written: ${formatDumpSegment(options.segment)}` +
-			` input=${formatFileUri(paths.providerInput)} ` +
-			`(${options.messages.length} msgs, ${toolSummary.toolCount} tools, ` +
-			`activateTools=${toolSummary.activateToolCount}${formatActivateToolNames(
-				toolSummary.activateToolNames,
-			)}) ` +
-			formatHostSettingsSummary(summarizeHostSettings()) +
-			` ${formatSystemPromptSummary(systemPromptSummary)}`,
+		formatRequestLogLine(
+			requestKind,
+			`providerInputDump written: ${formatDumpSegment(options.segment)}` +
+				` ${formatModelFields(options.modelInfo.id)}` +
+				` input=${formatFileUri(paths.providerInput)} ` +
+				`(${options.messages.length} msgs, ${toolSummary.toolCount} tools, ` +
+				`activateTools=${toolSummary.activateToolCount}${formatActivateToolNames(
+					toolSummary.activateToolNames,
+				)}) ` +
+				formatHostSettingsSummary(summarizeHostSettings()) +
+				` ${formatSystemPromptSummary(systemPromptSummary)}`,
+		),
 	);
 }
 
@@ -934,16 +1002,21 @@ function logRequestDump(
 	options: DumpDeepSeekRequestOptions,
 	paths: RequestDumpPaths,
 	requestJsonLength: number,
+	requestKind: RequestKind,
 ): void {
 	const systemPromptSummary = summarizeDeepSeekSystemPrompt(request.messages);
 	logger.debug(
-		`requestDump written: ${formatDumpSegment(options.segment)}` +
-			` request=${formatFileUri(paths.request)} ` +
-			`input=${formatFileUri(paths.input)} resolved=${formatFileUri(paths.resolved)} ` +
-			`(${request.messages.length} msgs, ${request.tools?.length ?? 0} tools, ` +
-			`~${(requestJsonLength / 1024).toFixed(0)} KB) ` +
-			formatHostSettingsSummary(summarizeHostSettings()) +
-			` ${formatSystemPromptSummary(systemPromptSummary)}`,
+		formatRequestLogLine(
+			requestKind,
+			`requestDump written: ${formatDumpSegment(options.segment)}` +
+				` ${formatModelFields(options.vscodeModelId, request.model)}` +
+				` request=${formatFileUri(paths.request)} ` +
+				`input=${formatFileUri(paths.input)} resolved=${formatFileUri(paths.resolved)} ` +
+				`(${request.messages.length} msgs, ${request.tools?.length ?? 0} tools, ` +
+				`~${(requestJsonLength / 1024).toFixed(0)} KB) ` +
+				formatHostSettingsSummary(summarizeHostSettings()) +
+				` ${formatSystemPromptSummary(systemPromptSummary)}`,
+		),
 	);
 }
 
@@ -963,7 +1036,22 @@ function formatDumpSegment(segment: ConversationSegment): string {
 }
 
 function formatHostSettingsSummary(settings: HostSettingsSummary): string {
-	return `hostFreezeCustomizationsIndex=${settings.copilotFreezeCustomizationsIndex}`;
+	return (
+		`hostFreezeCustomizationsIndex=${settings.copilotFreezeCustomizationsIndex}` +
+		` chatUtilityModel=${formatSettingValue(settings.chatUtilityModel)}` +
+		` chatUtilitySmallModel=${formatSettingValue(settings.chatUtilitySmallModel)}` +
+		` chatPlanAgentDefaultModel=${formatSettingValue(settings.chatPlanAgentDefaultModel)}` +
+		` chatExploreAgentDefaultModel=${formatSettingValue(settings.chatExploreAgentDefaultModel)}` +
+		` copilotAskAgentModel=${formatSettingValue(settings.copilotAskAgentModel)}` +
+		` copilotImplementAgentModel=${formatSettingValue(settings.copilotImplementAgentModel)}` +
+		` copilotExploreAgentModel=${formatSettingValue(settings.copilotExploreAgentModel)}`
+	);
+}
+
+function formatSettingValue(value: string | 'unknown'): string {
+	if (value === '') return 'empty';
+	if (value === 'unknown') return 'unknown';
+	return safeStringify(value);
 }
 
 function formatSystemPromptSummary(summary: SystemPromptSummary): string {

--- a/src/provider/debug/index.ts
+++ b/src/provider/debug/index.ts
@@ -1,0 +1,17 @@
+export {
+	createCacheDiagnosticsRecorder,
+	logToolFlowDiagnostics,
+	observeCancellationToken,
+} from './diagnostics';
+export type {
+	CacheDiagnosticsRecorder,
+	CacheDiagnosticsRun,
+	ReplayMarkerReportTrigger,
+} from './diagnostics';
+export { dumpDeepSeekRequest, dumpProviderInput, ensureRequestDumpRoot } from './dump';
+export {
+	classifyDeepSeekRequest,
+	classifyProviderRequest,
+	formatRequestLogLine,
+	type RequestKind,
+} from './classifier';

--- a/src/provider/index.ts
+++ b/src/provider/index.ts
@@ -4,8 +4,11 @@ import { getStabilizeToolListEnabled } from '../config';
 import { MODELS } from '../consts';
 import { t } from '../i18n';
 import { logger } from '../logger';
-import { createCacheDiagnosticsRecorder } from './diagnostics';
-import { dumpProviderInput } from './dump';
+import {
+	classifyProviderRequest,
+	createCacheDiagnosticsRecorder,
+	dumpProviderInput,
+} from './debug';
 import { toChatInfo } from './models';
 import { prepareChatRequest } from './request';
 import { resolveConversationSegment } from './segment';
@@ -132,6 +135,10 @@ export class DeepSeekChatProvider implements vscode.LanguageModelChatProvider {
 		token: vscode.CancellationToken,
 	): Promise<void> {
 		const segment = resolveConversationSegment(messages);
+		const requestKind = classifyProviderRequest({
+			messages,
+			tools: options.tools,
+		});
 
 		dumpProviderInput({
 			globalStorageUri: this.globalStorageUri,
@@ -139,6 +146,7 @@ export class DeepSeekChatProvider implements vscode.LanguageModelChatProvider {
 			modelInfo,
 			messages,
 			requestOptions: options,
+			requestKind,
 		});
 
 		const toolFlow = processToolFlow({
@@ -146,6 +154,7 @@ export class DeepSeekChatProvider implements vscode.LanguageModelChatProvider {
 			messages,
 			tools: options.tools,
 			progress,
+			requestKind,
 		});
 		if (toolFlow.preflightHandled) {
 			return;

--- a/src/provider/request.ts
+++ b/src/provider/request.ts
@@ -6,8 +6,13 @@ import { MODELS } from '../consts';
 import { t } from '../i18n';
 import type { DeepSeekRequest } from '../types';
 import { convertMessages, countMessageChars } from './convert';
-import type { CacheDiagnosticsRecorder, CacheDiagnosticsRun } from './diagnostics';
-import { dumpDeepSeekRequest } from './dump';
+import {
+	classifyDeepSeekRequest,
+	dumpDeepSeekRequest,
+	type CacheDiagnosticsRecorder,
+	type CacheDiagnosticsRun,
+	type RequestKind,
+} from './debug';
 import { getConfiguredThinkingEffort, type ModelConfigurationOptions } from './models';
 import type { ReplayMarkerMetadata } from './replay';
 import type { ConversationSegment } from './segment';
@@ -21,6 +26,7 @@ export interface PreparedChatRequest {
 	totalRequestChars: number;
 	trailingToolResultIds: string[];
 	cacheDiagnostics: CacheDiagnosticsRun;
+	requestKind: RequestKind;
 	segment: ConversationSegment;
 	replayMarkerMetadata: ReplayMarkerMetadata;
 	visionMarkerTextChars?: number;
@@ -82,9 +88,14 @@ export async function prepareChatRequest({
 				}
 			: {}),
 	};
+	const requestKind = classifyDeepSeekRequest({
+		request,
+		inputMessages: messages,
+	});
 	dumpDeepSeekRequest(request, {
 		globalStorageUri,
 		segment,
+		requestKind,
 		vscodeModelId: modelInfo.id,
 		isThinkingModel,
 		thinkingEffort,
@@ -99,6 +110,7 @@ export async function prepareChatRequest({
 	const diagnosticsRun = cacheDiagnostics.beginRequest({
 		request,
 		segment,
+		requestKind,
 		vscodeModelId: modelInfo.id,
 		isThinkingModel,
 		thinkingEffort,
@@ -116,6 +128,7 @@ export async function prepareChatRequest({
 		totalRequestChars,
 		trailingToolResultIds: collectTrailingToolResultIds(deepseekMessages),
 		cacheDiagnostics: diagnosticsRun,
+		requestKind,
 		segment,
 		replayMarkerMetadata: visionResolution.replayMarkerMetadata,
 		visionMarkerTextChars: visionResolution.stats.markerVisionTextChars || undefined,

--- a/src/provider/stream.ts
+++ b/src/provider/stream.ts
@@ -2,10 +2,11 @@ import vscode from 'vscode';
 import { logger } from '../logger';
 import type { DeepSeekToolCall, DeepSeekUsage } from '../types';
 import {
+	formatRequestLogLine,
 	observeCancellationToken,
 	type CacheDiagnosticsRun,
 	type ReplayMarkerReportTrigger,
-} from './diagnostics';
+} from './debug';
 import type { PreparedChatRequest } from './request';
 import {
 	createReplayMarkerPart,
@@ -191,7 +192,10 @@ function reportReplayMarker(
 			reasoningTextChars: state.accumulatedReasoning.length || undefined,
 			error,
 		});
-		logger.warn('Failed to report replay marker', error);
+		logger.warn(
+			formatRequestLogLine(prepared.requestKind, 'Failed to report replay marker'),
+			error,
+		);
 	}
 }
 

--- a/src/provider/tools/flow.ts
+++ b/src/provider/tools/flow.ts
@@ -1,6 +1,6 @@
 import vscode from 'vscode';
 import { t } from '../../i18n';
-import { logToolFlowDiagnostics } from '../diagnostics';
+import { logToolFlowDiagnostics, type RequestKind } from '../debug';
 import { ACTIVATE_TOOL_PREFIX, MAX_PREFLIGHT_ROUNDS_PER_USER_REQUEST } from './consts';
 import { createToolDriftNotice, filterProviderNotices } from './notices';
 import {
@@ -14,6 +14,7 @@ interface ToolFlowOptions {
 	messages: readonly vscode.LanguageModelChatRequestMessage[];
 	tools: readonly vscode.LanguageModelChatTool[] | undefined;
 	progress: vscode.Progress<vscode.LanguageModelResponsePart>;
+	requestKind: RequestKind;
 }
 
 interface ToolFlowResult {
@@ -27,12 +28,14 @@ export function processToolFlow({
 	messages,
 	tools,
 	progress,
+	requestKind,
 }: ToolFlowOptions): ToolFlowResult {
 	const filteredMessages = filterProviderNotices(filterPreflightControlFlow(messages));
 	const messagesFiltered = filteredMessages !== messages;
 
 	if (!stabilizeToolList) {
 		logToolFlowDiagnostics({
+			requestKind,
 			tools,
 			messagesFiltered,
 			preflight: 'skipped',
@@ -47,6 +50,7 @@ export function processToolFlow({
 	if (activatePreflight.remainingActivatorNames.length > 0) {
 		if (activatePreflight.rounds >= MAX_PREFLIGHT_ROUNDS_PER_USER_REQUEST) {
 			logToolFlowDiagnostics({
+				requestKind,
 				tools,
 				messagesFiltered,
 				preflight: 'round-limit',
@@ -59,6 +63,7 @@ export function processToolFlow({
 
 		const nextRound = activatePreflight.rounds + 1;
 		logToolFlowDiagnostics({
+			requestKind,
 			tools,
 			messagesFiltered,
 			preflight: 'handled',
@@ -82,6 +87,7 @@ export function processToolFlow({
 		activatePreflight.rounds > 0 &&
 		tools?.some((tool) => tool.name.startsWith(ACTIVATE_TOOL_PREFIX));
 	logToolFlowDiagnostics({
+		requestKind,
 		tools,
 		messagesFiltered,
 		preflight: 'ready',


### PR DESCRIPTION
## Summary
- group cache diagnostics and request dumps by provider-observable request kind
- separate terminal steering/todo/settings/background requests from main agent diagnostics
- keep same-scope cache comparisons across interleaved request streams and bound retained trace state

## Validation
- `npm run format:check`
- `npm run lint`
- `npm run compile`