### PR TITLE
feat(provider): show DeepSeek pricing in model picker

### DIFF
--- a/src/consts.ts
+++ b/src/consts.ts
@@ -62,6 +62,11 @@ export const MODELS: ModelDefinition[] = [
 			thinking: true,
 		},
 		requiresThinkingParam: true,
+		pricing: {
+			USD: { cacheHitInput: 0.0028, cacheMissInput: 0.14, output: 0.28 },
+			CNY: { cacheHitInput: 0.02, cacheMissInput: 1, output: 2 },
+		},
+		priceCategory: 'low',
 	},
 	{
 		id: 'deepseek-v4-pro',
@@ -77,5 +82,10 @@ export const MODELS: ModelDefinition[] = [
 			thinking: true,
 		},
 		requiresThinkingParam: true,
+		pricing: {
+			USD: { cacheHitInput: 0.003625, cacheMissInput: 0.435, output: 0.87 },
+			CNY: { cacheHitInput: 0.025, cacheMissInput: 3, output: 6 },
+		},
+		priceCategory: 'low',
 	},
 ];

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -21,6 +21,8 @@ const zh: Translations = {
 	// Model descriptions
 	'model.flash.detail': '快速高效',
 	'model.pro.detail': '深度推理',
+	'model.flash.tooltip': '快速高效的 DeepSeek V4 模型，推理能力接近 V4 Pro，API 定价更经济。',
+	'model.pro.tooltip': 'DeepSeek V4 模型，面向 Agent 编程、广泛世界知识和高阶推理任务。',
 
 	// API Key
 	'auth.apiKeyRequiredDetail': '请先配置 API Key',
@@ -205,6 +207,10 @@ const en: Translations = {
 	// Model descriptions
 	'model.flash.detail': 'Fast, general-purpose model',
 	'model.pro.detail': 'Most capable reasoning model',
+	'model.flash.tooltip':
+		'Fast, efficient DeepSeek V4 model with reasoning close to V4 Pro and economical API pricing.',
+	'model.pro.tooltip':
+		'DeepSeek V4 model for agentic coding, broad world knowledge, and high-end reasoning.',
 
 	// API Key
 	'auth.apiKeyRequiredDetail': 'Please run DeepSeek: Set API Key to configure.',

--- a/src/provider/index.ts
+++ b/src/provider/index.ts
@@ -10,6 +10,7 @@ import {
 	dumpProviderInput,
 } from './debug';
 import { toChatInfo } from './models';
+import { BalanceCurrencyResolver } from './pricing/currency';
 import { prepareChatRequest } from './request';
 import { resolveConversationSegment } from './segment';
 import { streamChatCompletion } from './stream';
@@ -34,6 +35,7 @@ export class DeepSeekChatProvider implements vscode.LanguageModelChatProvider {
 
 	/** Vision proxy: internal bridge + VS Code LM fallback. */
 	private readonly vision: ReturnType<typeof createVisionService>;
+	private readonly balanceCurrencyResolver: BalanceCurrencyResolver;
 
 	/**
 	 * Adaptive chars-per-token ratio, calibrated from actual usage data.
@@ -45,13 +47,19 @@ export class DeepSeekChatProvider implements vscode.LanguageModelChatProvider {
 		this.authManager = new AuthManager(context);
 		this.globalStorageUri = context.globalStorageUri;
 		this.vision = createVisionService(context);
+		this.balanceCurrencyResolver = new BalanceCurrencyResolver(context, this.authManager, () =>
+			this.onDidChangeLanguageModelChatInformationEmitter.fire(),
+		);
 
 		context.subscriptions.push(
 			this.onDidChangeLanguageModelChatInformationEmitter,
-			// Settings-based fallback API key + vision model changes.
+			// Settings-based fallback API key + base URL changes.
 			vscode.workspace.onDidChangeConfiguration((e) => {
-				if (e.affectsConfiguration('deepseek-copilot.apiKey')) {
-					this.onDidChangeLanguageModelChatInformationEmitter.fire();
+				if (
+					e.affectsConfiguration('deepseek-copilot.apiKey') ||
+					e.affectsConfiguration('deepseek-copilot.baseUrl')
+				) {
+					this.invalidateCurrencyAndRefreshModels();
 				}
 			}),
 			// Multi-window: SecretStorage changes don't fire onDidChangeConfiguration.
@@ -59,7 +67,7 @@ export class DeepSeekChatProvider implements vscode.LanguageModelChatProvider {
 			// model picker so the warning state stays in sync.
 			context.secrets.onDidChange((e) => {
 				if (e.key === 'deepseek-copilot.apiKey') {
-					this.onDidChangeLanguageModelChatInformationEmitter.fire();
+					this.invalidateCurrencyAndRefreshModels();
 				}
 			}),
 		);
@@ -70,13 +78,13 @@ export class DeepSeekChatProvider implements vscode.LanguageModelChatProvider {
 	async configureApiKey(): Promise<void> {
 		const saved = await this.authManager.promptForApiKey();
 		if (saved) {
-			this.onDidChangeLanguageModelChatInformationEmitter.fire();
+			this.invalidateCurrencyAndRefreshModels();
 		}
 	}
 
 	async clearApiKey(): Promise<void> {
 		await this.authManager.deleteApiKey();
-		this.onDidChangeLanguageModelChatInformationEmitter.fire();
+		this.invalidateCurrencyAndRefreshModels();
 		vscode.window.showInformationMessage(t('auth.removed'));
 	}
 
@@ -87,6 +95,13 @@ export class DeepSeekChatProvider implements vscode.LanguageModelChatProvider {
 	/** Force Copilot Chat to re-query model information (including configurationSchema). */
 	refreshModelPicker(): void {
 		this.onDidChangeLanguageModelChatInformationEmitter.fire();
+	}
+
+	private invalidateCurrencyAndRefreshModels(): void {
+		void this.balanceCurrencyResolver
+			.invalidate()
+			.catch((error) => logger.warn('Failed to invalidate DeepSeek balance currency', error))
+			.finally(() => this.onDidChangeLanguageModelChatInformationEmitter.fire());
 	}
 
 	async prepareForDeactivate(): Promise<void> {
@@ -120,7 +135,11 @@ export class DeepSeekChatProvider implements vscode.LanguageModelChatProvider {
 		}
 
 		const hasKey = await this.authManager.hasApiKey();
-		return MODELS.map((model) => toChatInfo(model, hasKey));
+		const pricingCurrency = this.balanceCurrencyResolver.getDisplayCurrency();
+		if (hasKey) {
+			this.balanceCurrencyResolver.refreshInBackground();
+		}
+		return MODELS.map((model) => toChatInfo(model, hasKey, pricingCurrency));
 	}
 
 	async provideLanguageModelChatResponse(

--- a/src/provider/models.ts
+++ b/src/provider/models.ts
@@ -1,15 +1,16 @@
 import vscode from 'vscode';
 import { t } from '../i18n';
-import type { ModelDefinition } from '../types';
+import type { ModelDefinition, PricingCurrency } from '../types';
+import { toModelCostInfo, type ModelCostInformation } from './pricing/costs';
 
 /**
  * NOTE: Non-public API surface.
  *
- * The fields below (`configurationSchema` on chat info, `modelConfiguration`
- * on response options, plus `isUserSelectable` / `statusIcon`) are not part
- * of the stable `vscode.LanguageModelChat*` typings yet. They are the same
- * shape currently consumed by GitHub Copilot Chat to render a per-model
- * config dropdown in the model picker.
+ * The fields below (`configurationSchema` on chat info, cost metadata,
+ * `modelConfiguration` on response options, plus `isUserSelectable` / `statusIcon`)
+ * are not part of the stable `vscode.LanguageModelChat*` typings yet. They are
+ * the same shape currently consumed by GitHub Copilot Chat to render model picker
+ * metadata and per-model configuration controls.
  */
 
 export type ThinkingEffort = 'none' | 'high' | 'max';
@@ -21,22 +22,27 @@ export type ModelConfigurationOptions = vscode.ProvideLanguageModelChatResponseO
 
 type ThinkingEffortConfigurationSchema = ReturnType<typeof buildThinkingEffortSchema>;
 
-export type ModelPickerChatInformation = vscode.LanguageModelChatInformation & {
-	readonly isUserSelectable: boolean;
-	readonly statusIcon?: vscode.ThemeIcon;
-	readonly configurationSchema?: ThinkingEffortConfigurationSchema;
-};
+export type ModelPickerChatInformation = vscode.LanguageModelChatInformation &
+	ModelCostInformation & {
+		readonly isUserSelectable: boolean;
+		readonly statusIcon?: vscode.ThemeIcon;
+		readonly configurationSchema?: ThinkingEffortConfigurationSchema;
+	};
 
-export function toChatInfo(m: ModelDefinition, hasApiKey: boolean): ModelPickerChatInformation {
-	const detailKey = resolveDetailKey(m);
-	const modelDetail = detailKey ? t(detailKey) : m.detail;
+export function toChatInfo(
+	m: ModelDefinition,
+	hasApiKey: boolean,
+	pricingCurrency?: PricingCurrency,
+): ModelPickerChatInformation {
+	const modelDetail = resolveModelText(m, 'detail') ?? m.detail;
+	const modelTooltip = resolveModelText(m, 'tooltip');
 	return {
 		id: m.id,
 		name: m.name,
 		family: m.family,
 		version: m.version,
 		detail: hasApiKey ? modelDetail : t('auth.apiKeyRequiredDetail'),
-		tooltip: hasApiKey ? undefined : t('auth.apiKeyRequiredDetail'),
+		tooltip: hasApiKey ? modelTooltip : t('auth.apiKeyRequiredDetail'),
 		statusIcon: hasApiKey ? undefined : new vscode.ThemeIcon('warning'),
 		maxInputTokens: m.maxInputTokens,
 		maxOutputTokens: m.maxOutputTokens,
@@ -45,6 +51,7 @@ export function toChatInfo(m: ModelDefinition, hasApiKey: boolean): ModelPickerC
 			toolCalling: m.capabilities.toolCalling,
 			imageInput: m.capabilities.imageInput,
 		},
+		...toModelCostInfo(m, pricingCurrency),
 		...(m.capabilities.thinking ? { configurationSchema: buildThinkingEffortSchema() } : {}),
 	};
 }
@@ -84,9 +91,9 @@ function buildThinkingEffortSchema() {
 	} as const;
 }
 
-function resolveDetailKey(m: ModelDefinition): string | undefined {
+function resolveModelText(m: ModelDefinition, field: 'detail' | 'tooltip'): string | undefined {
 	const suffix = m.id.startsWith('deepseek-v4-') ? m.id.slice('deepseek-v4-'.length) : m.id;
-	const key = `model.${suffix}.detail`;
+	const key = `model.${suffix}.${field}`;
 	const translated = t(key);
-	return translated !== key ? key : undefined;
+	return translated !== key ? translated : undefined;
 }

--- a/src/provider/pricing/costs.ts
+++ b/src/provider/pricing/costs.ts
@@ -1,0 +1,48 @@
+import type { ModelDefinition, PriceCategory, PricingCurrency } from '../../types';
+
+/**
+ * VS Code's proposed cost fields are documented as numeric credits, but the
+ * current Copilot UI renders them textually. We intentionally pass formatted
+ * currency labels here so BYOK prices appear in the native cost slots.
+ * If a future UI parses these fields numerically, expect NaN or missing costs;
+ * remove the formatted fields from this one mapping point when that happens.
+ *
+ * Mapping:
+ * - inputCost  <- cacheMissInput, the representative non-cached input price.
+ * - cacheCost  <- cacheHitInput, shown separately as the cached-input tier.
+ * - outputCost <- output.
+ *
+ * priceCategory is emitted only together with concrete official pricing; incomplete
+ * pricing intentionally suppresses all cost metadata.
+ */
+export interface ModelCostInformation {
+	readonly inputCost?: string;
+	readonly outputCost?: string;
+	readonly cacheCost?: string;
+	readonly priceCategory?: PriceCategory;
+}
+
+export function toModelCostInfo(
+	model: ModelDefinition,
+	currency?: PricingCurrency,
+): ModelCostInformation {
+	if (!currency) {
+		return {};
+	}
+
+	const pricing = model.pricing?.[currency];
+	if (!pricing) {
+		return {};
+	}
+
+	return {
+		...(model.priceCategory ? { priceCategory: model.priceCategory } : {}),
+		inputCost: formatPriceValue(pricing.cacheMissInput, currency),
+		outputCost: formatPriceValue(pricing.output, currency),
+		cacheCost: formatPriceValue(pricing.cacheHitInput, currency),
+	};
+}
+
+function formatPriceValue(value: number, currency: PricingCurrency): string {
+	return `${currency === 'CNY' ? '¥' : '$'}${value}`;
+}

--- a/src/provider/pricing/currency.ts
+++ b/src/provider/pricing/currency.ts
@@ -1,0 +1,232 @@
+import vscode from 'vscode';
+import { AuthManager } from '../../auth';
+import { OFFICIAL_DEEPSEEK_API_HOST } from '../../client/consts';
+import { getBaseUrl } from '../../config';
+import { logger } from '../../logger';
+import type { PricingCurrency } from '../../types';
+
+const CACHE_KEY = 'deepseek-copilot.balanceCurrency.cache';
+const BALANCE_TIMEOUT_MS = 5000;
+
+interface CachedBalanceCurrency {
+	readonly version: 1;
+	readonly currency: PricingCurrency;
+	readonly baseUrl: string;
+}
+
+interface DeepSeekBalanceInfo {
+	readonly currency?: unknown;
+	readonly total_balance?: unknown;
+	readonly topped_up_balance?: unknown;
+}
+
+interface DeepSeekBalanceResponse {
+	readonly balance_infos?: unknown;
+}
+
+export class BalanceCurrencyResolver {
+	private inFlight: Promise<void> | undefined;
+	private controller: AbortController | undefined;
+	private generation = 0;
+	private resolved: CachedBalanceCurrency | undefined;
+
+	constructor(
+		private readonly context: vscode.ExtensionContext,
+		private readonly authManager: AuthManager,
+		private readonly onDidChangeCurrency: () => void,
+	) {}
+
+	getDisplayCurrency(): PricingCurrency | undefined {
+		const baseUrl = normalizeBaseUrl(getBaseUrl());
+		if (!isOfficialDeepSeekBaseUrl(baseUrl)) {
+			return undefined;
+		}
+
+		if (this.resolved?.baseUrl === baseUrl) {
+			return this.resolved.currency;
+		}
+
+		const cached = this.readCache();
+		if (cached?.baseUrl === baseUrl) {
+			return cached.currency;
+		}
+
+		return getLocaleFallbackCurrency();
+	}
+
+	refreshInBackground(): void {
+		if (this.inFlight || !this.needsRefresh()) {
+			return;
+		}
+
+		const controller = new AbortController();
+		const generation = this.generation;
+		const refresh = this.refreshFromBalance(controller, generation)
+			.catch((error) => {
+				if (!(isAbortError(error) && generation !== this.generation)) {
+					logger.warn('Failed to refresh DeepSeek balance currency', error);
+				}
+			})
+			.finally(() => {
+				if (this.inFlight === refresh) {
+					this.inFlight = undefined;
+				}
+				if (this.controller === controller) {
+					this.controller = undefined;
+				}
+			});
+		this.controller = controller;
+		this.inFlight = refresh;
+	}
+
+	async invalidate(): Promise<void> {
+		this.generation++;
+		this.controller?.abort();
+		await this.inFlight;
+		this.resolved = undefined;
+		await this.context.globalState.update(CACHE_KEY, undefined);
+	}
+
+	private needsRefresh(): boolean {
+		const baseUrl = normalizeBaseUrl(getBaseUrl());
+		if (!isOfficialDeepSeekBaseUrl(baseUrl)) {
+			return false;
+		}
+
+		if (this.resolved?.baseUrl === baseUrl || this.readCache()?.baseUrl === baseUrl) {
+			return false;
+		}
+
+		return true;
+	}
+
+	private async refreshFromBalance(controller: AbortController, generation: number): Promise<void> {
+		const baseUrl = normalizeBaseUrl(getBaseUrl());
+		if (!isOfficialDeepSeekBaseUrl(baseUrl)) {
+			return;
+		}
+
+		const apiKey = await this.authManager.getApiKey();
+		if (!apiKey) {
+			return;
+		}
+
+		const currency = await fetchBalanceCurrency(baseUrl, apiKey, controller);
+		if (!currency || controller.signal.aborted || generation !== this.generation) {
+			return;
+		}
+
+		const previous = this.resolved ?? this.readCache();
+		this.resolved = { version: 1, currency, baseUrl };
+		await this.context.globalState.update(CACHE_KEY, this.resolved);
+		if (previous?.baseUrl !== baseUrl || previous.currency !== currency) {
+			this.onDidChangeCurrency();
+		}
+	}
+
+	private readCache(): CachedBalanceCurrency | undefined {
+		const value = this.context.globalState.get<unknown>(CACHE_KEY);
+		if (!isCachedBalanceCurrency(value)) {
+			return undefined;
+		}
+		return value;
+	}
+}
+
+export function isOfficialDeepSeekBaseUrl(baseUrl: string): boolean {
+	try {
+		return new URL(baseUrl).hostname.toLowerCase() === OFFICIAL_DEEPSEEK_API_HOST;
+	} catch {
+		return false;
+	}
+}
+
+export function normalizeBaseUrl(baseUrl: string): string {
+	return baseUrl.trim().replace(/\/+$/u, '');
+}
+
+function getLocaleFallbackCurrency(): PricingCurrency {
+	return vscode.env.language.toLowerCase().startsWith('zh') ? 'CNY' : 'USD';
+}
+
+function getBalanceUrl(baseUrl: string): string {
+	return new URL('/user/balance', baseUrl).toString();
+}
+
+async function fetchBalanceCurrency(
+	baseUrl: string,
+	apiKey: string,
+	controller: AbortController,
+): Promise<PricingCurrency | undefined> {
+	const timeout = setTimeout(() => controller.abort(), BALANCE_TIMEOUT_MS);
+
+	try {
+		const balanceUrl = getBalanceUrl(baseUrl);
+		const response = await fetch(balanceUrl, {
+			method: 'GET',
+			headers: { Authorization: `Bearer ${apiKey}` },
+			signal: controller.signal,
+		});
+
+		if (!response.ok) {
+			logger.debug(`DeepSeek balance request failed with HTTP ${response.status}`);
+			return undefined;
+		}
+
+		const data = (await response.json()) as DeepSeekBalanceResponse;
+		return chooseBalanceCurrency(data);
+	} finally {
+		clearTimeout(timeout);
+	}
+}
+
+function chooseBalanceCurrency(data: DeepSeekBalanceResponse): PricingCurrency | undefined {
+	if (!Array.isArray(data.balance_infos)) {
+		return undefined;
+	}
+
+	const infos = data.balance_infos.filter(isDeepSeekBalanceInfo);
+	return (
+		findCurrencyByPositiveBalance(infos, 'topped_up_balance') ??
+		findCurrencyByPositiveBalance(infos, 'total_balance') ??
+		infos.map((info) => parsePricingCurrency(info.currency)).find(Boolean)
+	);
+}
+
+function findCurrencyByPositiveBalance(
+	infos: readonly DeepSeekBalanceInfo[],
+	key: 'total_balance' | 'topped_up_balance',
+): PricingCurrency | undefined {
+	for (const info of infos) {
+		const currency = parsePricingCurrency(info.currency);
+		if (currency && Number(info[key]) > 0) {
+			return currency;
+		}
+	}
+	return undefined;
+}
+
+function parsePricingCurrency(value: unknown): PricingCurrency | undefined {
+	return value === 'USD' || value === 'CNY' ? value : undefined;
+}
+
+function isDeepSeekBalanceInfo(value: unknown): value is DeepSeekBalanceInfo {
+	return typeof value === 'object' && value !== null;
+}
+
+function isAbortError(value: unknown): boolean {
+	return value instanceof Error && value.name === 'AbortError';
+}
+
+function isCachedBalanceCurrency(value: unknown): value is CachedBalanceCurrency {
+	if (typeof value !== 'object' || value === null) {
+		return false;
+	}
+
+	const cache = value as CachedBalanceCurrency;
+	return (
+		cache.version === 1 &&
+		parsePricingCurrency(cache.currency) !== undefined &&
+		typeof cache.baseUrl === 'string'
+	);
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -93,6 +93,16 @@ export interface StreamCallbacks {
 
 // ---- Model definitions ----
 
+export type PricingCurrency = 'USD' | 'CNY';
+
+export type PriceCategory = 'low' | 'medium' | 'high' | 'very_high';
+
+export interface ModelPricing {
+	cacheHitInput: number;
+	cacheMissInput: number;
+	output: number;
+}
+
 export interface ModelDefinition {
 	id: string;
 	name: string;
@@ -107,4 +117,6 @@ export interface ModelDefinition {
 		thinking: boolean;
 	};
 	requiresThinkingParam: boolean;
+	pricing?: Readonly<Record<PricingCurrency, ModelPricing>>;
+	priceCategory?: PriceCategory;
 }


### PR DESCRIPTION
## Summary
- add official DeepSeek per-1M token pricing metadata for V4 Flash and Pro
- infer display currency from the official /user/balance API with locale fallback
- localize model tooltips and suppress pricing on non-official base URLs

## Notes
- cost fields intentionally pass formatted currency strings because current Copilot UI renders them textually; if upstream switches to numeric parsing, remove this at src/provider/pricing/costs.ts
- priceCategory is emitted only when concrete official pricing is available

## Verification
- npm run format:check
- npm run compile
- npm run lint