### PR TITLE
fix(provider): disable thinking for internal helper requests

### DIFF
--- a/src/provider/debug/diagnostics.ts
+++ b/src/provider/debug/diagnostics.ts
@@ -4,18 +4,18 @@ import { getDebugLoggingEnabled } from '../../config';
 import { LANGUAGE_MODEL_CHAT_SYSTEM_ROLE } from '../../consts';
 import { logger } from '../../logger';
 import type { DeepSeekMessage, DeepSeekRequest, DeepSeekTool, DeepSeekUsage } from '../../types';
+import {
+	classifyDeepSeekRequest,
+	formatModelFields,
+	formatRequestLogLine,
+	type RequestKind,
+} from '../routing';
 import { REPLAY_MARKER_MIME, parseFirstReplayMarker } from '../replay';
 import type { ConversationSegment } from '../segment';
 import { ACTIVATE_TOOL_PREFIX } from '../tools/consts';
 import type { ActivatePreflightInspection } from '../tools/preflight';
 import { IMAGE_DESCRIPTION_UNAVAILABLE } from '../vision/consts';
 import type { VisionProxySource, VisionResolutionStats as VisionPipelineStats } from '../vision';
-import {
-	classifyDeepSeekRequest,
-	formatModelFields,
-	formatRequestLogLine,
-	type RequestKind,
-} from './classifier';
 
 const LARGE_MESSAGE_CHARS = 10_000;
 const HASH_WINDOW_CHARS = 2_048;

--- a/src/provider/debug/dump.ts
+++ b/src/provider/debug/dump.ts
@@ -8,17 +8,17 @@ import { LANGUAGE_MODEL_CHAT_SYSTEM_ROLE } from '../../consts';
 import { safeStringify, toWellFormedString } from '../../json';
 import { logger } from '../../logger';
 import type { DeepSeekMessage, DeepSeekRequest } from '../../types';
-import { parseReplayMarkerData, REPLAY_MARKER_MIME } from '../replay';
-import type { ConversationSegment } from '../segment';
-import { ACTIVATE_TOOL_PREFIX } from '../tools/consts';
-import type { VisionProxySource, VisionResolutionStats } from '../vision';
 import {
 	classifyDeepSeekRequest,
 	classifyProviderRequest,
 	formatModelFields,
 	formatRequestLogLine,
 	type RequestKind,
-} from './classifier';
+} from '../routing';
+import { parseReplayMarkerData, REPLAY_MARKER_MIME } from '../replay';
+import type { ConversationSegment } from '../segment';
+import { ACTIVATE_TOOL_PREFIX } from '../tools/consts';
+import type { VisionProxySource, VisionResolutionStats } from '../vision';
 
 let dumpCounter = 0;
 let providerInputDumpCounter = 0;

--- a/src/provider/debug/index.ts
+++ b/src/provider/debug/index.ts
@@ -9,9 +9,3 @@ export type {
 	ReplayMarkerReportTrigger,
 } from './diagnostics';
 export { dumpDeepSeekRequest, dumpProviderInput, ensureRequestDumpRoot } from './dump';
-export {
-	classifyDeepSeekRequest,
-	classifyProviderRequest,
-	formatRequestLogLine,
-	type RequestKind,
-} from './classifier';

--- a/src/provider/index.ts
+++ b/src/provider/index.ts
@@ -4,14 +4,11 @@ import { getStabilizeToolListEnabled } from '../config';
 import { MODELS } from '../consts';
 import { t } from '../i18n';
 import { logger } from '../logger';
-import {
-	classifyProviderRequest,
-	createCacheDiagnosticsRecorder,
-	dumpProviderInput,
-} from './debug';
+import { createCacheDiagnosticsRecorder, dumpProviderInput } from './debug';
 import { toChatInfo } from './models';
 import { BalanceCurrencyResolver } from './pricing/currency';
 import { prepareChatRequest } from './request';
+import { classifyProviderRequest } from './routing';
 import { resolveConversationSegment } from './segment';
 import { streamChatCompletion } from './stream';
 import { estimateTokenCount } from './tokens';

--- a/src/provider/request.ts
+++ b/src/provider/request.ts
@@ -7,13 +7,12 @@ import { t } from '../i18n';
 import type { DeepSeekRequest } from '../types';
 import { convertMessages, countMessageChars } from './convert';
 import {
-	classifyDeepSeekRequest,
 	dumpDeepSeekRequest,
 	type CacheDiagnosticsRecorder,
 	type CacheDiagnosticsRun,
-	type RequestKind,
 } from './debug';
 import { getConfiguredThinkingEffort, type ModelConfigurationOptions } from './models';
+import { classifyDeepSeekRequest, shouldForceThinkingNone, type RequestKind } from './routing';
 import type { ReplayMarkerMetadata } from './replay';
 import type { ConversationSegment } from './segment';
 import { collectTrailingToolResultIds, prepareRequestTools } from './tools/request';
@@ -64,7 +63,6 @@ export async function prepareChatRequest({
 	const client = new DeepSeekClient(getBaseUrl(), apiKey);
 	const modelDef = MODELS.find((m) => m.id === modelInfo.id);
 	const isThinkingModel = modelDef?.capabilities.thinking ?? false;
-	const thinkingEffort = getConfiguredThinkingEffort(options as ModelConfigurationOptions);
 	const maxTokens = getMaxTokens();
 
 	const visionResolution = await resolveImageMessages(messages, token, getVisionDescriber);
@@ -73,13 +71,24 @@ export async function prepareChatRequest({
 	const tools = prepareRequestTools(modelDef?.capabilities.toolCalling, options);
 
 	const totalRequestChars = countMessageChars(deepseekMessages);
-	const request: DeepSeekRequest = {
+	const baseRequest: DeepSeekRequest = {
 		model: getApiModelId(modelInfo.id),
 		messages: deepseekMessages,
 		stream: true,
 		tools,
 		tool_choice: tools && tools.length > 0 ? ('auto' as const) : undefined,
 		max_tokens: maxTokens,
+	};
+	const requestKind = classifyDeepSeekRequest({
+		request: baseRequest,
+		inputMessages: messages,
+	});
+	const configuredThinkingEffort = getConfiguredThinkingEffort(
+		options as ModelConfigurationOptions,
+	);
+	const thinkingEffort = shouldForceThinkingNone(requestKind) ? 'none' : configuredThinkingEffort;
+	const request: DeepSeekRequest = {
+		...baseRequest,
 		...(isThinkingModel
 			? {
 					thinking: {
@@ -89,10 +98,6 @@ export async function prepareChatRequest({
 				}
 			: {}),
 	};
-	const requestKind = classifyDeepSeekRequest({
-		request,
-		inputMessages: messages,
-	});
 	dumpDeepSeekRequest(request, {
 		globalStorageUri,
 		segment,

--- a/src/provider/routing/classifier.ts
+++ b/src/provider/routing/classifier.ts
@@ -6,14 +6,41 @@ export type RequestKind =
 	| 'terminal-steering'
 	| 'todo-tracker'
 	| 'settings-resolver'
+	| 'prompt-categorizer'
+	| 'chat-title'
+	| 'inline-progress-message'
+	| 'git-branch-name'
+	| 'git-commit-message'
+	| 'rename-suggestions'
 	| 'background'
 	| 'unknown';
 
 const TODO_TRACKER_PREFIX = 'You are a background task tracker';
+const PROMPT_CATEGORIZER_PREFIX = 'You are an expert classifier for AI coding assistant prompts';
 const SETTINGS_RESOLVER_PREFIX =
 	'You are a Visual Studio Code assistant. Your job is to assist users in using Visual Studio Code by returning settings';
+const CHAT_TITLE_PREFIXES = [
+	'You are an expert in crafting ultra-compact titles',
+	'You are an expert in crafting pithy titles',
+] as const;
+const INLINE_PROGRESS_MESSAGE_PREFIX =
+	'You are an expert in writing short, catchy, and encouraging progress messages';
+const GIT_BRANCH_NAME_PREFIX = 'You are an expert in crafting pithy branch names';
+const GIT_COMMIT_MESSAGE_PREFIX =
+	'You are an AI programming assistant, helping a software developer to come with the best git commit message';
+const RENAME_SUGGESTIONS_PREFIX = 'You are a distinguished software engineer';
 const MAIN_AGENT_PREFIX = 'You are an expert AI programming assistant';
 const TERMINAL_NOTIFICATION_PATTERN = /^\[Terminal\s+\S+\s+notification:/;
+const REQUEST_KINDS_WITH_FORCED_NONE_THINKING = new Set<RequestKind>([
+	'todo-tracker',
+	'prompt-categorizer',
+	'settings-resolver',
+	'chat-title',
+	'inline-progress-message',
+	'git-branch-name',
+	'git-commit-message',
+	'rename-suggestions',
+]);
 
 export function formatModelFields(vscodeModelId: string, apiModelId?: string): string {
 	const apiField = apiModelId && apiModelId !== vscodeModelId ? ` apiModel=${apiModelId}` : '';
@@ -22,6 +49,10 @@ export function formatModelFields(vscodeModelId: string, apiModelId?: string): s
 
 export function formatRequestLogLine(requestKind: RequestKind, message: string): string {
 	return `[${requestKind}] ${message}`;
+}
+
+export function shouldForceThinkingNone(requestKind: RequestKind): boolean {
+	return REQUEST_KINDS_WITH_FORCED_NONE_THINKING.has(requestKind);
 }
 
 export function classifyProviderRequest(input: {
@@ -66,8 +97,29 @@ function classifyRequest(input: {
 	) {
 		return 'todo-tracker';
 	}
+	if (
+		isOnlyTool(input.toolNames, 'categorize_prompt') ||
+		firstText.startsWith(PROMPT_CATEGORIZER_PREFIX)
+	) {
+		return 'prompt-categorizer';
+	}
 	if (firstText.startsWith(SETTINGS_RESOLVER_PREFIX)) {
 		return 'settings-resolver';
+	}
+	if (startsWithAny(firstText, CHAT_TITLE_PREFIXES)) {
+		return 'chat-title';
+	}
+	if (firstText.startsWith(INLINE_PROGRESS_MESSAGE_PREFIX)) {
+		return 'inline-progress-message';
+	}
+	if (firstText.startsWith(GIT_BRANCH_NAME_PREFIX)) {
+		return 'git-branch-name';
+	}
+	if (firstText.startsWith(GIT_COMMIT_MESSAGE_PREFIX)) {
+		return 'git-commit-message';
+	}
+	if (firstText.startsWith(RENAME_SUGGESTIONS_PREFIX)) {
+		return 'rename-suggestions';
 	}
 	if (
 		firstText.startsWith(MAIN_AGENT_PREFIX) ||
@@ -84,6 +136,10 @@ function classifyRequest(input: {
 
 function isOnlyTool(toolNames: readonly string[], toolName: string): boolean {
 	return toolNames.length === 1 && toolNames[0] === toolName;
+}
+
+function startsWithAny(text: string, prefixes: readonly string[]): boolean {
+	return prefixes.some((prefix) => text.startsWith(prefix));
 }
 
 function getDeepSeekToolName(tool: DeepSeekTool): string {

--- a/src/provider/routing/index.ts
+++ b/src/provider/routing/index.ts
@@ -1,0 +1,8 @@
+export {
+	classifyDeepSeekRequest,
+	classifyProviderRequest,
+	formatModelFields,
+	formatRequestLogLine,
+	shouldForceThinkingNone,
+	type RequestKind,
+} from './classifier';

--- a/src/provider/stream.ts
+++ b/src/provider/stream.ts
@@ -3,11 +3,11 @@ import { createUserFacingError } from '../client';
 import { logger } from '../logger';
 import type { DeepSeekToolCall, DeepSeekUsage } from '../types';
 import {
-	formatRequestLogLine,
 	observeCancellationToken,
 	type CacheDiagnosticsRun,
 	type ReplayMarkerReportTrigger,
 } from './debug';
+import { formatRequestLogLine } from './routing';
 import {
 	createReplayMarkerPart,
 	hasReplayMarkerMetadata,

--- a/src/provider/tools/flow.ts
+++ b/src/provider/tools/flow.ts
@@ -1,6 +1,7 @@
 import vscode from 'vscode';
 import { t } from '../../i18n';
-import { logToolFlowDiagnostics, type RequestKind } from '../debug';
+import { logToolFlowDiagnostics } from '../debug';
+import type { RequestKind } from '../routing';
 import { ACTIVATE_TOOL_PREFIX, MAX_PREFLIGHT_ROUNDS_PER_USER_REQUEST } from './consts';
 import { createToolDriftNotice, filterProviderNotices } from './notices';
 import {


### PR DESCRIPTION
Summary:
- Force thinking=none for recognized internal helper requests
- Move request classification out of debug into provider routing
- Keep debug diagnostics consuming routing metadata

Checks:
- npm run format:check
- npm run compile
- npm run lint