### PR TITLE
fix(provider): dedupe streaming usage reports

### DIFF
--- a/src/client/core.ts
+++ b/src/client/core.ts
@@ -5,6 +5,7 @@ import type {
 	DeepSeekRequest,
 	DeepSeekStreamChunk,
 	DeepSeekToolCall,
+	DeepSeekUsage,
 	StreamCallbacks,
 } from '../types';
 import { createHttpError, formatRequestError, normalizeRequestError } from './error';
@@ -64,6 +65,7 @@ export class DeepSeekClient {
 			const reader = response.body.getReader();
 			const decoder = new TextDecoder();
 			let buffer = '';
+			let latestUsage: DeepSeekUsage | undefined;
 
 			// Accumulate tool call deltas by index, then emit on finish_reason=stop/tool_calls
 			const pendingToolCalls = new Map<number, DeepSeekToolCall>();
@@ -97,6 +99,7 @@ export class DeepSeekClient {
 							callbacks.onToolCall(tc);
 						}
 						pendingToolCalls.clear();
+						reportFinalUsage(callbacks, latestUsage);
 						callbacks.onDone();
 						return;
 					}
@@ -110,9 +113,10 @@ export class DeepSeekClient {
 						const chunk: DeepSeekStreamChunk = JSON.parse(jsonStr);
 						const choice = chunk.choices?.[0];
 
-						// Capture usage stats from the API for token-count calibration.
-						if (chunk.usage && callbacks.onUsage) {
-							callbacks.onUsage(chunk.usage);
+						// Some OpenAI-compatible providers emit usage on every streaming chunk.
+						// Keep only the latest value and report it once when the stream completes.
+						if (chunk.usage) {
+							latestUsage = chunk.usage;
 						}
 
 						if (!choice) {
@@ -166,6 +170,7 @@ export class DeepSeekClient {
 				}
 			}
 
+			reportFinalUsage(callbacks, latestUsage);
 			callbacks.onDone();
 		} catch (error) {
 			if (isAbortError(error) && cancellationToken?.isCancellationRequested) {
@@ -178,6 +183,13 @@ export class DeepSeekClient {
 			cancelListener?.dispose();
 		}
 	}
+}
+
+function reportFinalUsage(callbacks: StreamCallbacks, usage: DeepSeekUsage | undefined): void {
+	if (!usage || !callbacks.onUsage) {
+		return;
+	}
+	callbacks.onUsage(usage);
 }
 
 function isAbortError(error: unknown): boolean {

--- a/src/provider/stream.ts
+++ b/src/provider/stream.ts
@@ -7,7 +7,7 @@ import {
 	type CacheDiagnosticsRun,
 	type ReplayMarkerReportTrigger,
 } from './debug';
-import { formatRequestLogLine } from './routing';
+import { formatRequestLogLine, type RequestKind } from './routing';
 import {
 	createReplayMarkerPart,
 	hasReplayMarkerMetadata,
@@ -89,7 +89,7 @@ export function streamChatCompletion({
 					);
 					setCharsPerToken(charsPerToken);
 					prepared.cacheDiagnostics.onUsage(usage, charsPerToken);
-					reportCopilotContextUsage(progress, usage);
+					reportCopilotContextUsage(progress, usage, prepared.requestKind);
 				},
 			},
 			token,
@@ -267,6 +267,7 @@ function updateCharsPerToken(
 function reportCopilotContextUsage(
 	progress: vscode.Progress<vscode.LanguageModelResponsePart>,
 	usage: DeepSeekUsage,
+	requestKind: RequestKind,
 ): void {
 	const data = {
 		prompt_tokens: usage.prompt_tokens,
@@ -277,10 +278,14 @@ function reportCopilotContextUsage(
 		},
 	};
 
-	progress.report(
-		new vscode.LanguageModelDataPart(
-			new TextEncoder().encode(JSON.stringify(data)),
-			COPILOT_USAGE_DATA_PART_MIME,
-		),
-	);
+	try {
+		progress.report(
+			new vscode.LanguageModelDataPart(
+				new TextEncoder().encode(JSON.stringify(data)),
+				COPILOT_USAGE_DATA_PART_MIME,
+			),
+		);
+	} catch (error) {
+		logger.warn(formatRequestLogLine(requestKind, 'Failed to report usage data'), error);
+	}
 }


### PR DESCRIPTION
## Summary

- Dedupe streaming usage emissions in the SSE client and forward only the final usage payload.
- Keep downstream usage reporting simple while avoiding SiliconFlow per-chunk output log spam.
- Guard VS Code usage data reporting so a rejected data part does not block replay marker or cache diagnostics.

Fixes #134

## Test plan

- npm run compile
- npm run lint
- npm run format:check
