### PR TITLE
docs(readme): clarify custom agent model syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,20 @@ Example `settings.json` override for compatible API proxies:
 | One-click install | ✅ | ❌ | ✅ |
 | API key in OS keychain | ✅ | ❌ | ⚠️ varies |
 
+## Custom Agents (.agent.md)
+
+- Use this exact syntax for the `model` field, with the lowercase vendor name 'deepseek' in parenthesis
+
+```yaml
+model: 'DeepSeek V4 Flash (deepseek)'
+```
+
+- If using both Pro and Flash
+
+```yaml
+model: ['DeepSeek V4 Flash (deepseek)', 'DeepSeek V4 Pro (deepseek)']
+```
+
 ## License
 
 [MIT](LICENSE)


### PR DESCRIPTION
Addresses #175

Was not sure where in the readme to put this, eventually settled on adding it to the end before License.

Was not sure if this belonged under resources/walkthrough or readme, but felt it was relevant enough to be added into readme (when I reviewed documentation I did not realize there was a walkthrough section at first). Apologies if this was incorrect.

No hard feelings if the PR is denied, always open to feedback so I can improve future contributions. Tried my best to match your internal commit standards and markdown/writing style.

Cheers!