### PR TITLE
feat(vision-proxy): add configurable request timeout

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -61,9 +61,11 @@ const zh: Translations = {
 	'vision.panel.field.modelId': '模型 ID',
 	'vision.panel.field.customHeaders': '自定义 headers JSON',
 	'vision.panel.field.extraBody': '额外请求体 JSON',
+	'vision.panel.field.timeoutMs': '请求超时 (毫秒)',
 	'vision.panel.hint.customHeaders':
 		'Header 会随配置保存。建议尽量把服务商 token 放在 API Key 输入框中。',
 	'vision.panel.hint.extraBody': '会合并进请求体，不能覆盖 model、messages、input 或 stream。',
+	'vision.panel.hint.timeoutMs': '留空使用默认 30 秒。值必须大于 0。',
 	'vision.panel.placeholder.openaiEndpoint': 'https://api.example.com/v1/chat/completions',
 	'vision.panel.placeholder.openaiResponsesEndpoint': 'https://api.example.com/v1/responses',
 	'vision.panel.placeholder.anthropicEndpoint': 'https://api.example.com/v1/messages',
@@ -253,10 +255,12 @@ const en: Translations = {
 	'vision.panel.field.modelId': 'Model ID',
 	'vision.panel.field.customHeaders': 'Custom headers JSON',
 	'vision.panel.field.extraBody': 'Additional request body JSON',
+	'vision.panel.field.timeoutMs': 'Request timeout (ms)',
 	'vision.panel.hint.customHeaders':
 		'Header values are stored with the profile. Put provider tokens in the API key field when possible.',
 	'vision.panel.hint.extraBody':
 		'Merged into the request body. Cannot override model, messages, input, or stream.',
+	'vision.panel.hint.timeoutMs': 'Leave empty for the default 30 seconds. Must be greater than 0.',
 	'vision.panel.placeholder.openaiEndpoint': 'https://api.example.com/v1/chat/completions',
 	'vision.panel.placeholder.openaiResponsesEndpoint': 'https://api.example.com/v1/responses',
 	'vision.panel.placeholder.anthropicEndpoint': 'https://api.example.com/v1/messages',

--- a/src/provider/vision/consts.ts
+++ b/src/provider/vision/consts.ts
@@ -1,3 +1,13 @@
+/**
+ * Upper bound for the vision proxy request timeout in milliseconds.
+ *
+ * Node's `setTimeout()` treats any delay larger than `2_147_483_647` ms as
+ * `1` ms, which would produce an almost immediate timeout. This cap (about
+ * 24.86 days) is far above any realistic vision request, so it only guards
+ * against oversized user input.
+ */
+export const MAX_TIMEOUT_MS = 2_147_483_647;
+
 /** Default model ID used for the vision proxy when auto-detection is enabled. */
 export const DEFAULT_VISION_MODEL_ID = 'oswe-vscode-prime';
 

--- a/src/provider/vision/protocols/client.ts
+++ b/src/provider/vision/protocols/client.ts
@@ -46,7 +46,7 @@ export class VisionProxyClient {
 			context,
 			headers,
 			body,
-			timeoutMs: DEFAULT_TIMEOUT_MS,
+			timeoutMs: config.timeoutMs ?? DEFAULT_TIMEOUT_MS,
 			token: request.token,
 		});
 
@@ -184,13 +184,14 @@ function createVisionProxyRequestDiagnostics(
 	request: VisionDescriptionRequest,
 	apiKey: string | undefined,
 ): VisionProxyRequestDiagnostics {
+	const timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
 	return {
 		phase,
 		providerFamily: config.providerFamily,
 		apiType: config.apiType,
 		modelId: config.modelId,
 		endpoint,
-		timeoutMs: DEFAULT_TIMEOUT_MS,
+		timeoutMs,
 		hasApiKey: Boolean(apiKey?.trim()),
 		headerNames: Object.keys(headers).sort(),
 		imageCount: request.images.length,

--- a/src/provider/vision/sources/endpoint/config.ts
+++ b/src/provider/vision/sources/endpoint/config.ts
@@ -1,14 +1,14 @@
 import type vscode from 'vscode';
 import { t } from '../../../../i18n';
+import { VisionProxyError } from '../../protocols/errors';
+import { normalizeCustomHeaders } from '../../protocols/headers';
+import { validateVisionEndpointUrl } from '../../protocols/url';
 import type {
 	VisionProxyApiType,
 	VisionProxyConfig,
 	VisionProxyProviderFamily,
 	VisionProxySource,
 } from '../../types';
-import { VisionProxyError } from '../../protocols/errors';
-import { normalizeCustomHeaders } from '../../protocols/headers';
-import { validateVisionEndpointUrl } from '../../protocols/url';
 
 export const VISION_PROXY_CONFIG_KEY = 'deepseek-copilot.visionProxy.config';
 export const VISION_PROXY_SOURCE_KEY = 'deepseek-copilot.visionProxy.source';
@@ -77,12 +77,14 @@ export function normalizeVisionProxyConfig(value: unknown): VisionProxyConfig {
 	const modelId = normalizeRequiredString(value.modelId, t('vision.panel.field.modelId'));
 	const headers = normalizeCustomHeaders(value.headers);
 	const extraBody = normalizeExtraBody(value.extraBody);
+	const timeoutMs = normalizeTimeoutMs(value.timeoutMs);
 
 	return {
 		providerFamily,
 		apiType,
 		url,
 		modelId,
+		timeoutMs,
 		headers,
 		extraBody,
 		updatedAt: typeof value.updatedAt === 'number' ? value.updatedAt : Date.now(),
@@ -154,6 +156,23 @@ function normalizeExtraBody(value: unknown): Record<string, unknown> | undefined
 	}
 
 	return Object.keys(normalized).length > 0 ? normalized : undefined;
+}
+
+/**
+ * Normalize the user-supplied timeout in milliseconds.
+ *
+ * Returns `undefined` (→ fall back to {@link DEFAULT_TIMEOUT_MS}) when the
+ * value is missing, not a finite number, or ≤ 0.  No upper cap is enforced.
+ */
+function normalizeTimeoutMs(value: unknown): number | undefined {
+	if (value === undefined || value === null) {
+		return undefined;
+	}
+	const num = Number(value);
+	if (!Number.isFinite(num) || num <= 0) {
+		return undefined;
+	}
+	return num;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/provider/vision/sources/endpoint/config.ts
+++ b/src/provider/vision/sources/endpoint/config.ts
@@ -9,6 +9,7 @@ import type {
 	VisionProxyProviderFamily,
 	VisionProxySource,
 } from '../../types';
+import { MAX_TIMEOUT_MS } from '../../consts';
 
 export const VISION_PROXY_CONFIG_KEY = 'deepseek-copilot.visionProxy.config';
 export const VISION_PROXY_SOURCE_KEY = 'deepseek-copilot.visionProxy.source';
@@ -162,7 +163,10 @@ function normalizeExtraBody(value: unknown): Record<string, unknown> | undefined
  * Normalize the user-supplied timeout in milliseconds.
  *
  * Returns `undefined` (→ fall back to {@link DEFAULT_TIMEOUT_MS}) when the
- * value is missing, not a finite number, or ≤ 0.  No upper cap is enforced.
+ * value is missing, not a finite number, or ≤ 0. Values above
+ * {@link MAX_TIMEOUT_MS} are clamped to the cap, and non-integer values are
+ * truncated, because Node's `setTimeout()` treats delays larger than
+ * `2_147_483_647` ms as `1` ms and truncates fractional delays.
  */
 function normalizeTimeoutMs(value: unknown): number | undefined {
 	if (value === undefined || value === null) {
@@ -172,7 +176,7 @@ function normalizeTimeoutMs(value: unknown): number | undefined {
 	if (!Number.isFinite(num) || num <= 0) {
 		return undefined;
 	}
-	return num;
+	return Math.min(Math.trunc(num), MAX_TIMEOUT_MS);
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/provider/vision/types.ts
+++ b/src/provider/vision/types.ts
@@ -24,6 +24,7 @@ export interface VisionProxyConfig {
 	apiType: VisionProxyApiType;
 	url: string;
 	modelId: string;
+	timeoutMs?: number;
 	headers?: Record<string, string>;
 	extraBody?: Record<string, unknown>;
 	updatedAt: number;

--- a/src/provider/vision/ui/html.ts
+++ b/src/provider/vision/ui/html.ts
@@ -110,6 +110,11 @@ export function getVisionProxyPanelHtml(
 }"></textarea>
 						<div class="hint">${escapeHtml(strings.hintExtraBody)}</div>
 					</div>
+					<div class="field">
+						<label for="timeoutMs">${escapeHtml(strings.fieldTimeoutMs)}</label>
+						<input id="timeoutMs" type="number" min="1" placeholder="30000">
+						<div class="hint">${escapeHtml(strings.hintTimeoutMs)}</div>
+					</div>
 				</div>
 			</fieldset>
 			<div class="actions">
@@ -170,8 +175,10 @@ function getVisionProxyPanelStrings() {
 		fieldModelId: t('vision.panel.field.modelId'),
 		fieldCustomHeaders: t('vision.panel.field.customHeaders'),
 		fieldExtraBody: t('vision.panel.field.extraBody'),
+		fieldTimeoutMs: t('vision.panel.field.timeoutMs'),
 		hintCustomHeaders: t('vision.panel.hint.customHeaders'),
 		hintExtraBody: t('vision.panel.hint.extraBody'),
+		hintTimeoutMs: t('vision.panel.hint.timeoutMs'),
 		placeholderOpenAIEndpoint: t('vision.panel.placeholder.openaiEndpoint'),
 		placeholderOpenAIResponsesEndpoint: t('vision.panel.placeholder.openaiResponsesEndpoint'),
 		placeholderAnthropicEndpoint: t('vision.panel.placeholder.anthropicEndpoint'),

--- a/src/provider/vision/ui/html.ts
+++ b/src/provider/vision/ui/html.ts
@@ -112,7 +112,7 @@ export function getVisionProxyPanelHtml(
 					</div>
 					<div class="field">
 						<label for="timeoutMs">${escapeHtml(strings.fieldTimeoutMs)}</label>
-						<input id="timeoutMs" type="number" min="1" placeholder="30000">
+						<input id="timeoutMs" type="number" min="1" max="2147483647" step="1" placeholder="30000">
 						<div class="hint">${escapeHtml(strings.hintTimeoutMs)}</div>
 					</div>
 				</div>

--- a/src/provider/vision/ui/script.ts
+++ b/src/provider/vision/ui/script.ts
@@ -297,7 +297,9 @@ export function getVisionProxyPanelScript(initialState: string, initialStrings: 
 
 		// Parse a positive integer from the timeout input field.
 		// Returns undefined for empty, non-finite, or ≤ 0 values so the
-		// backend falls back to the default timeout.
+		// backend falls back to the default timeout. Values above
+		// MAX_TIMEOUT_MS are clamped and fractional values are truncated,
+		// mirroring the backend normalization.
 		function parsePositiveNumber(value) {
 			const text = value.trim();
 			if (!text) {
@@ -307,7 +309,7 @@ export function getVisionProxyPanelScript(initialState: string, initialStrings: 
 			if (!Number.isFinite(num) || num <= 0) {
 				return undefined;
 			}
-			return num;
+			return Math.min(Math.trunc(num), 2147483647);
 		}
 
 		function parseOptionalJson(value, label) {

--- a/src/provider/vision/ui/script.ts
+++ b/src/provider/vision/ui/script.ts
@@ -21,6 +21,7 @@ export function getVisionProxyPanelScript(initialState: string, initialStrings: 
 		const modelId = document.getElementById('modelId');
 		const headers = document.getElementById('headers');
 		const extraBody = document.getElementById('extraBody');
+		const timeoutMs = document.getElementById('timeoutMs');
 		const status = document.getElementById('status');
 		const testResult = document.getElementById('testResult');
 		const testImage = document.getElementById('testImage');
@@ -46,6 +47,7 @@ export function getVisionProxyPanelScript(initialState: string, initialStrings: 
 			modelId.value = config.modelId || '';
 			headers.value = config.headers ? JSON.stringify(config.headers, null, 2) : '';
 			extraBody.value = config.extraBody ? JSON.stringify(config.extraBody, null, 2) : '';
+			timeoutMs.value = config.timeoutMs ? String(config.timeoutMs) : '';
 			apiKey.value = '';
 			apiKey.placeholder = state.hasApiKey ? '••••••••••••' : strings.placeholderEnterApiKey;
 			renderApiKeyHint(state.hasApiKey);
@@ -279,6 +281,7 @@ export function getVisionProxyPanelScript(initialState: string, initialStrings: 
 		function collectConfig() {
 			const parsedHeaders = parseOptionalJson(headers.value, strings.fieldCustomHeaders);
 			const parsedExtraBody = parseOptionalJson(extraBody.value, strings.fieldExtraBody);
+			const timeoutValue = parsePositiveNumber(timeoutMs.value);
 			const endpointConfig = getEndpointTypeConfig(endpointType.value);
 			return {
 				providerFamily: endpointConfig.providerFamily,
@@ -287,8 +290,24 @@ export function getVisionProxyPanelScript(initialState: string, initialStrings: 
 				modelId: modelId.value,
 				headers: parsedHeaders,
 				extraBody: parsedExtraBody,
+				timeoutMs: timeoutValue,
 				updatedAt: Date.now(),
 			};
+		}
+
+		// Parse a positive integer from the timeout input field.
+		// Returns undefined for empty, non-finite, or ≤ 0 values so the
+		// backend falls back to the default timeout.
+		function parsePositiveNumber(value) {
+			const text = value.trim();
+			if (!text) {
+				return undefined;
+			}
+			const num = Number(text);
+			if (!Number.isFinite(num) || num <= 0) {
+				return undefined;
+			}
+			return num;
 		}
 
 		function parseOptionalJson(value, label) {
@@ -449,7 +468,7 @@ export function getVisionProxyPanelScript(initialState: string, initialStrings: 
 			invalidateTestStatus();
 			updateEndpointTypeFromUrl();
 		});
-		for (const field of [apiKey, modelId, headers, extraBody]) {
+		for (const field of [apiKey, modelId, headers, extraBody, timeoutMs]) {
 			field.addEventListener('input', invalidateTestStatus);
 		}
 		endpointType.addEventListener('change', () => {


### PR DESCRIPTION
## Summary

Adds an optional **Request timeout (ms)** field to the Vision Proxy
settings panel so users can increase the HTTP timeout for slow vision
API endpoints. Previously the timeout was hardcoded at 30 seconds.

## Behavior

| Input | Result |
|---|---|
| Empty / not set | Falls back to the existing default (30 000 ms) |
| Any positive number | Used as the fetch timeout for vision requests |
| Zero, negative, or non-finite | Treated as unset → falls back to default |
| No upper cap | No arbitrary limit — users decide what works for their endpoint |

## Files changed

- `src/provider/vision/types.ts` — add optional `timeoutMs` to
  `VisionProxyConfig`
- `src/provider/vision/sources/endpoint/config.ts` — add
  `normalizeTimeoutMs()` (validates > 0, no cap)
- `src/provider/vision/protocols/client.ts` — use
  `config.timeoutMs ?? DEFAULT_TIMEOUT_MS`
- `src/provider/vision/ui/html.ts` — add `<input type="number">` field
  with label + hint
- `src/provider/vision/ui/script.ts` — wire `parsePositiveNumber()`,
  `applyState`, `collectConfig` for the new field
- `src/i18n.ts` — add `field.timeoutMs` / `hint.timeoutMs` strings for
  both `en` and `zh` dictionaries

## Screenshots

<img width="819" height="366" alt="image" src="https://github.com/user-attachments/assets/76d6790b-39f5-470a-9ce3-8182eaf4d080" />

## Translation review requested

The Chinese (`zh`) translations for the new strings were written with the
help of an AI assistant.  A native speaker should review them:

```ts
// i18n.ts — zh dictionary
'vision.panel.field.timeoutMs': '请求超时 (毫秒)',
'vision.panel.hint.timeoutMs': '留空使用默认 30 秒。值必须大于 0。',
```

Corresponding English:

```ts
'vision.panel.field.timeoutMs': 'Request timeout (ms)',
'vision.panel.hint.timeoutMs': 'Leave empty for the default 30 seconds. Must be greater than 0.',
```

🙏 Please flag anything that sounds unnatural or could be improved.