### PR TITLE
feat(client): recognize Novita as a compatible provider for error links

### DIFF
--- a/src/client/consts.ts
+++ b/src/client/consts.ts
@@ -16,17 +16,29 @@ export const API_PROVIDER_HTTP_ERROR_LINKS: Readonly<
 			labelKey: 'error.action.createApiKey',
 			url: EXTERNAL_URLS.deepseek.apiKeys,
 		},
+		novita: {
+			labelKey: 'error.action.createApiKey',
+			url: EXTERNAL_URLS.novita.apiKeys,
+		},
 	},
 	402: {
 		deepseek: {
 			labelKey: 'error.action.viewUsage',
 			url: EXTERNAL_URLS.deepseek.usage,
 		},
+		novita: {
+			labelKey: 'error.action.viewUsage',
+			url: EXTERNAL_URLS.novita.usage,
+		},
 	},
 	'5xx': {
 		deepseek: {
 			labelKey: 'error.action.checkDeepSeekStatus',
 			url: EXTERNAL_URLS.deepseek.status,
+		},
+		novita: {
+			labelKey: 'error.action.checkNovitaStatus',
+			url: EXTERNAL_URLS.novita.status,
 		},
 	},
 };

--- a/src/client/error/index.ts
+++ b/src/client/error/index.ts
@@ -1,4 +1,4 @@
-import { isOfficialDeepSeekBaseUrl } from '../../endpoint';
+import { isNovitaBaseUrl, isOfficialDeepSeekBaseUrl } from '../../endpoint';
 import { t } from '../../i18n';
 import { safeStringify } from '../../json';
 import { API_PROVIDER_HTTP_ERROR_LINKS, MAX_DIAGNOSTIC_FIELD_LENGTH } from '../consts';
@@ -319,7 +319,13 @@ function escapeBoldText(value: string): string {
 }
 
 function identifyApiProvider(baseUrl: string): ApiProviderId | undefined {
-	return isOfficialDeepSeekBaseUrl(baseUrl) ? 'deepseek' : undefined;
+	if (isOfficialDeepSeekBaseUrl(baseUrl)) {
+		return 'deepseek';
+	}
+	if (isNovitaBaseUrl(baseUrl)) {
+		return 'novita';
+	}
+	return undefined;
 }
 
 function getHttpErrorLinkStatusKey(status: number): HttpErrorLinkStatusKey | undefined {

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -20,7 +20,7 @@ export interface HttpErrorLinkDefinition {
 	url: string;
 }
 
-export type ApiProviderId = 'deepseek';
+export type ApiProviderId = 'deepseek' | 'novita';
 export type HttpErrorLinkStatusKey = 401 | 402 | '5xx';
 
 export type DeepSeekRequestErrorKind = 'http' | 'network' | 'unknown';

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -17,6 +17,11 @@ export const EXTERNAL_URLS = {
 		usage: 'https://platform.deepseek.com/usage',
 		status: 'https://status.deepseek.com',
 	},
+	novita: {
+		apiKeys: 'https://novita.ai/settings/key-management',
+		usage: 'https://novita.ai/billing',
+		status: 'https://status.novita.ai',
+	},
 } as const;
 
 /** URI path handled by this extension to reveal the output log. */

--- a/src/endpoint.ts
+++ b/src/endpoint.ts
@@ -1,10 +1,19 @@
 export const OFFICIAL_DEEPSEEK_API_HOST = 'api.deepseek.com';
+export const NOVITA_API_HOST = 'api.novita.ai';
 
 export function isOfficialDeepSeekBaseUrl(baseUrl: string): boolean {
+	return getBaseUrlHostname(baseUrl) === OFFICIAL_DEEPSEEK_API_HOST;
+}
+
+export function isNovitaBaseUrl(baseUrl: string): boolean {
+	return getBaseUrlHostname(baseUrl) === NOVITA_API_HOST;
+}
+
+function getBaseUrlHostname(baseUrl: string): string | undefined {
 	try {
-		return new URL(baseUrl).hostname.toLowerCase() === OFFICIAL_DEEPSEEK_API_HOST;
+		return new URL(baseUrl).hostname.toLowerCase();
 	} catch {
-		return false;
+		return undefined;
 	}
 }
 

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -181,6 +181,7 @@ const zh: Translations = {
 	'error.action.createApiKey': '创建 API Key',
 	'error.action.viewUsage': '用量',
 	'error.action.checkDeepSeekStatus': 'DeepSeek 状态',
+	'error.action.checkNovitaStatus': 'Novita 状态',
 	'error.action.viewDetails': '错误详情',
 	'error.network.dns': '[{0}] DNS 解析失败。请检查网络连接、防火墙或代理设置，以及自定义 baseUrl。',
 	'error.network.unreachable':
@@ -396,6 +397,7 @@ const en: Translations = {
 	'error.action.createApiKey': 'Create API Key',
 	'error.action.viewUsage': 'Usage',
 	'error.action.checkDeepSeekStatus': 'DeepSeek Status',
+	'error.action.checkNovitaStatus': 'Novita Status',
 	'error.action.viewDetails': 'Error Details',
 	'error.network.dns':
 		'[{0}] DNS lookup failed. Check your network connection, firewall, or proxy settings, and your custom baseUrl.',


### PR DESCRIPTION

## Summary

- Recognize `api.novita.ai` as a known-compatible base URL alongside `api.deepseek.com`
- Add Novita's API-key, usage, and status URLs to the provider-aware HTTP error action links (401/402/5xx)

## Why

`deepseek-copilot.baseUrl` already lets users point this extension at any OpenAI-compatible endpoint, and Novita's `/openai/v1` endpoint matches the SSE response shape this client parses (`delta.content`, `delta.reasoning_content`, `usage`). Users who set `baseUrl` to Novita currently fall back to the generic error message instead of getting a direct link to create a key, check usage, or check status the way DeepSeek users do.

## Validation

- `npm run format:check`
- `npm run compile`
- `npm run lint`
- Verified against the live Novita API: `GET /openai/v1/models` (307 models, `deepseek/deepseek-v4-pro` active), non-streaming and streaming chat completions against `deepseek/deepseek-v4-flash` return the same field shape this client's `DeepSeekClient` parses (`delta.reasoning_content`, `usage`, `[DONE]`)
