### PR TITLE
fix(provider): expose low reasoning effort for DeepSeek V4 Pro

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This proxy is a compatibility bridge; if DeepSeek native vision becomes availabl
 </p>
 
 ### Thinking Mode with Reasoning Effort Control
-Full support for DeepSeek V4's `reasoning_content`. DeepSeek V4 Flash offers `none` (off), `low` (light reasoning), `high` (balanced, default), and `max` (deep reasoning for hard agent tasks). DeepSeek V4 Pro currently offers `none`, `high`, and `max`, matching the effort levels implemented by the official API.
+Full support for DeepSeek V4's `reasoning_content`. DeepSeek V4 Flash and Pro both offer `none` (off), `low` (light reasoning), `high` (balanced, default), and `max` (deep reasoning for hard agent tasks), matching the effort levels implemented by the official API.
 
 ### Inherits Every Copilot Capability
 Because this plugs into Copilot's native provider API, you get the full stack for free:
@@ -91,7 +91,7 @@ Install from the registry used by your editor:
 | Model | Thinking Effort | Best For |
 |---|---|---|
 | **DeepSeek V4 Flash** | `none` / `low` / `high` / `max` | Fast everyday coding, quick edits, cheap iteration |
-| **DeepSeek V4 Pro** | `none` / `high` / `max` | Complex refactors, agent tasks, deep reasoning |
+| **DeepSeek V4 Pro** | `none` / `low` / `high` / `max` | Complex refactors, agent tasks, deep reasoning |
 
 Both support optional thinking mode, tool calling, and 1M token context.
 

--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -45,7 +45,7 @@ DeepSeek V4 是纯文本模型。将截图拖入聊天，本扩展会自动将�
 </p>
 
 ### 思考模式与推理深度控制
-完整支持 DeepSeek V4 的 `reasoning_content`。DeepSeek V4 Flash 可选择 `停用`、`轻量`、`标准`（均衡，默认）或 `深度`（适用于复杂 Agent 任务）；DeepSeek V4 Pro 目前提供 `停用`、`标准` 和 `深度`，与官方 API 已实现的推理档位保持一致。
+完整支持 DeepSeek V4 的 `reasoning_content`。DeepSeek V4 Flash 和 Pro 均可选择 `停用`、`轻量`、`标准`（均衡，默认）或 `深度`（适用于复杂 Agent 任务），与官方 API 已实现的推理档位保持一致。
 
 ### 继承全部 Copilot 能力
 由于本扩展接入的是 Copilot 的原生 provider API，你免费获得完整能力栈：
@@ -91,7 +91,7 @@ API Key 存储在 VS Code 的 `SecretStorage` 中（macOS 钥匙串 / Windows �
 | 模型 | 思考深度 | 适用场景 |
 |---|---|---|
 | **DeepSeek V4 Flash** | `停用` / `轻量` / `标准` / `深度` | 日常快速编码、小改动、低成本迭代 |
-| **DeepSeek V4 Pro** | `停用` / `标准` / `深度` | 复杂重构、Agent 任务、深度推理 |
+| **DeepSeek V4 Pro** | `停用` / `轻量` / `标准` / `深度` | 复杂重构、Agent 任务、深度推理 |
 
 两者均支持可选的思考模式、工具调用和 1M Token 上下文。
 

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -84,7 +84,7 @@ export const MODELS: ModelDefinition[] = [
 			toolCalling: DEEPSEEK_TOOLS_LIMIT,
 			imageInput: true,
 			thinking: {
-				supportedEfforts: ['high', 'max'],
+				supportedEfforts: ['low', 'high', 'max'],
 				defaultEffort: 'high',
 				canDisable: true,
 			},


### PR DESCRIPTION
## Summary

- expose the `low` reasoning effort for DeepSeek V4 Pro in the Copilot model picker
- keep `high` as the default effort
- update the English and Simplified Chinese READMEs to document the full Pro effort list

## Why

DeepSeek V4 Pro now accepts `low` reasoning effort, but the extension's model metadata still advertised only `high` and `max`. As a result, VS Code could not offer the newly supported level.

## Validation

- `npm run compile`
- `npm run lint`
- `npm run format:check`
- verified in an Extension Development Host that Pro exposes the Low option
- verified that a Pro Low request sends `model: "deepseek-v4-pro"` with `reasoning_effort: "low"`
- ran matched Pro Low and High prompts successfully through the VS Code UI

Closes #231