### PR TITLE
chore(community): add issue and pull request intake

### DIFF
--- a/.github/CONTACT.md
+++ b/.github/CONTACT.md
@@ -1,0 +1,12 @@
+# Contact the Maintainer / 联系维护者
+
+Email: **deepseek-copilot@proton.me**
+
+Use this address for project-related matters that are better handled privately, including:<br>以下事项如不适合通过公开 Issue 讨论，可以通过邮件联系：
+
+- Maintenance and project collaboration / 项目维护与协作
+- Sensitive security risks / 敏感安全风险
+- Provider or service-related matters that should not be discussed publicly / 不适合公开讨论的 Provider 或服务相关事项
+- Anything else you prefer not to discuss in a public Issue / 其他不愿在公开 Issue 中讨论的事项
+
+A brief description is enough. Do not send credentials or API keys.<br>简单说明事项即可，请勿发送账号凭据或 API Key。

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,70 @@
+name: Bug Report / Bug 反馈
+description: Report a problem with the extension
+title: "[Bug] "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please search existing Issues before submitting.<br>提交前请先搜索已有 Issue。请勿公开 API Key、Authorization Header、私有 Prompt、私有代码或未经检查的敏感日志。
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Describe the actual and expected behavior. Include the exact error text or a screenshot when available.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: How can we reproduce it?
+      description: Provide the smallest sequence of steps, or explain when the problem occurs if it is not reliably reproducible.
+    validations:
+      required: true
+
+  - type: input
+    id: extension-version
+    attributes:
+      label: Extension version
+      placeholder: Exact version shown in Extensions
+    validations:
+      required: true
+
+  - type: textarea
+    id: editor-build
+    attributes:
+      label: Editor build
+      description: >-
+        Run "Help: About" from the Command Palette and paste the Version,
+        Commit, and OS. Name the editor if it is not VS Code Stable.
+      placeholder: "Paste the Help: About output here."
+      render: text
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context, if relevant
+      description: |
+        Add only what helps reproduce the problem, such as the model, Chat mode, official API or custom baseUrl, local or remote environment, recent updates, redacted settings, logs, or screenshots.
+
+        If you manually installed or switched Copilot Chat, include its exact version and installation method.
+
+        To collect diagnostic logs:
+        1. Open Settings and search for "DeepSeek Copilot: Debug Mode".
+        2. Select "Metadata" and reproduce the problem.
+        3. Run "DeepSeek: Show Logs" from the Command Palette.
+
+        Review the logs before attaching them. Do not share Verbose request dumps publicly.
+
+  - type: checkboxes
+    id: confirmations
+    attributes:
+      label: Confirmations
+      options:
+        - label: I searched existing Issues and did not find the same problem.
+          required: true
+        - label: I confirmed that the public content contains no API keys, authorization headers, private prompts, private code, or unreviewed sensitive dumps.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Contact the Maintainer / 联系维护者
+    url: https://github.com/Vizards/deepseek-v4-for-copilot/blob/main/.github/CONTACT.md
+    about: Maintenance collaboration, sensitive security reports, or matters not suited to public discussion

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,61 @@
+name: Feature Request / 功能建议
+description: Propose a user problem for consideration before implementation
+title: "[Feature] "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Describe the problem before proposing an implementation.<br>请先描述需要解决的问题，再讨论具体实现。
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: User problem
+      description: Describe the concrete limitation or task.
+    validations:
+      required: true
+
+  - type: textarea
+    id: desired-outcome
+    attributes:
+      label: Desired outcome
+      description: Describe the result, not an implementation plan.
+    validations:
+      required: true
+
+  - type: textarea
+    id: beneficiaries
+    attributes:
+      label: Who benefits?
+      description: Identify the affected user group and usage context.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Existing options
+      description: List current settings or workarounds and what remains unsolved.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: implementation
+    attributes:
+      label: Are you willing to implement it?
+      options:
+        - "Yes"
+        - "No"
+        - Not sure
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: confirmations
+    attributes:
+      label: Confirmation
+      options:
+        - label: I searched existing Issues and did not find the same request.
+          required: true
+        - label: I confirmed that there is no open pull request for the same request.
+          required: true

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,40 @@
+name: Question / 使用咨询
+description: Ask the community about using or understanding the extension
+title: "[Question] "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Questions are intended primarily for community discussion and peer support.<br>此分类主要用于社区互助交流。
+
+        If you have confirmed unexpected extension behavior, use the [Bug Report](https://github.com/Vizards/deepseek-v4-for-copilot/issues/new?template=bug-report.yml) form and provide reproducible information.<br>如果确认是扩展异常，请使用 [Bug Report / Bug 报告](https://github.com/Vizards/deepseek-v4-for-copilot/issues/new?template=bug-report.yml) 并提供可复现信息。
+
+  - type: textarea
+    id: question
+    attributes:
+      label: Question
+      description: Describe what you are trying to understand or accomplish.
+    validations:
+      required: true
+
+  - type: textarea
+    id: attempts
+    attributes:
+      label: What have you tried?
+      description: Mention relevant documentation, settings, or existing Issues you checked.
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context, if relevant
+      description: Add versions, screenshots, or links only when they help explain the question.
+
+  - type: checkboxes
+    id: confirmations
+    attributes:
+      label: Confirmation
+      options:
+        - label: I searched the README and existing Issues before opening this question.
+          required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,14 +24,10 @@ Write N/A if there are no related issues.
 
 <!-- State what changed and what intentionally did not change. -->
 
-## User-facing text
+## Author confirmation
 
-<!-- Check one. -->
+By submitting this pull request, I confirm that:
 
-- [ ] No user-facing text changed
-- [ ] User-facing text was updated in both English and Chinese
-
-## Final checks
-
-- [ ] I reviewed and can explain every change
-- [ ] This PR contains no API keys, authorization headers, private prompts, private code, or unreviewed sensitive logs
+- I reviewed and can explain every change.
+- I reviewed any user-facing text changes in both English and Chinese.
+- This pull request contains no API keys, authorization headers, private prompts, private code, or unreviewed sensitive logs.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,10 +24,8 @@ Write N/A if there are no related issues.
 
 <!-- State what changed and what intentionally did not change. -->
 
-## Author confirmation
+## Final checks
 
-By submitting this pull request, I confirm that:
-
-- I reviewed and can explain every change.
-- I reviewed any user-facing text changes in both English and Chinese.
-- This pull request contains no API keys, authorization headers, private prompts, private code, or unreviewed sensitive logs.
+- [ ] I reviewed and can explain every change
+- [ ] I reviewed any user-facing text changes in both English and Chinese
+- [ ] This pull request contains no API keys, authorization headers, private prompts, private code, or unreviewed sensitive logs

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,37 @@
+<!--
+For non-trivial changes, opening a related Issue first is recommended.
+Pull requests that fall outside the project scope or are not ready for review may be closed without a detailed code review.
+
+Provider presets, fixed endpoints, branded links, and Marketplace exposure may be closed if submitted without prior discussion.
+For matters better handled privately, see Contact the Maintainer:
+https://github.com/Vizards/deepseek-v4-for-copilot/blob/main/.github/CONTACT.md
+-->
+
+## Related issues
+
+<!--
+Link all relevant issues.
+Use one "Closes #123" line for each issue fully resolved by this PR.
+Use "Related to #123" for context-only links.
+Write N/A if there are no related issues.
+-->
+
+## Problem
+
+<!-- What user problem does this solve? -->
+
+## Changes and scope
+
+<!-- State what changed and what intentionally did not change. -->
+
+## User-facing text
+
+<!-- Check one. -->
+
+- [ ] No user-facing text changed
+- [ ] User-facing text was updated in both English and Chinese
+
+## Final checks
+
+- [ ] I reviewed and can explain every change
+- [ ] This PR contains no API keys, authorization headers, private prompts, private code, or unreviewed sensitive logs

--- a/.github/workflows/batch-issue-maintenance.yml
+++ b/.github/workflows/batch-issue-maintenance.yml
@@ -1,0 +1,121 @@
+name: Batch reply to Issues
+
+run-name: Batch reply to ${{ inputs.issue_numbers }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      issue_numbers:
+        description: "Issue numbers separated by commas or spaces (for example: 12, #34, 56)"
+        required: true
+        type: string
+      reply_body:
+        description: "Markdown reply; use \\n for line breaks"
+        required: true
+        type: string
+      close_issues:
+        description: Close Issues after replying
+        required: true
+        type: boolean
+        default: false
+      state_reason:
+        description: Close reason (used only when closing)
+        required: true
+        type: choice
+        default: completed
+        options:
+          - completed
+          - not_planned
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: batch-issue-maintenance
+  cancel-in-progress: false
+
+jobs:
+  process-issues:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Reply and optionally close
+        uses: actions/github-script@v9
+        env:
+          ISSUE_NUMBERS: ${{ inputs.issue_numbers }}
+          REPLY_BODY: ${{ inputs.reply_body }}
+          CLOSE_ISSUES: ${{ inputs.close_issues }}
+          STATE_REASON: ${{ inputs.state_reason }}
+        with:
+          script: |
+            const rawNumbers = process.env.ISSUE_NUMBERS ?? '';
+            const rawReply = process.env.REPLY_BODY ?? '';
+            const closeIssues = process.env.CLOSE_ISSUES === 'true';
+            const stateReason = process.env.STATE_REASON;
+
+            const tokens = rawNumbers.split(/[\s,]+/).filter(Boolean);
+            const invalidTokens = tokens.filter((token) => !/^#?[1-9]\d*$/.test(token));
+
+            if (invalidTokens.length > 0) {
+              throw new Error(`Invalid Issue number(s): ${invalidTokens.join(', ')}`);
+            }
+
+            const issueNumbers = [
+              ...new Set(tokens.map((token) => Number(token.replace(/^#/, '')))),
+            ];
+
+            if (issueNumbers.length === 0) {
+              throw new Error('Enter at least one Issue number.');
+            }
+
+            if (issueNumbers.length > 100) {
+              throw new Error('Process at most 100 Issues in one run.');
+            }
+
+            const replyBody = rawReply.replace(/\\n/g, '\n').trim();
+            if (!replyBody) {
+              throw new Error('Reply must not be empty.');
+            }
+
+            const targets = [];
+            for (const issueNumber of issueNumbers) {
+              const { data: issue } = await github.rest.issues.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+              });
+
+              if (issue.pull_request) {
+                throw new Error(`#${issueNumber} is a pull request. No Issues were changed.`);
+              }
+              if (issue.state !== 'open') {
+                throw new Error(`#${issueNumber} is not open. No Issues were changed.`);
+              }
+              targets.push(issue);
+            }
+
+            core.info(
+              `Processing ${targets.length} Issue(s); close after replying: ${closeIssues}`,
+            );
+
+            for (const issue of targets) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: replyBody,
+              });
+
+              if (closeIssues) {
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  state: 'closed',
+                  state_reason: stateReason,
+                });
+              }
+
+              core.notice(`#${issue.number}: ${closeIssues ? 'replied and closed' : 'replied'}`);
+            }

--- a/.github/workflows/close-inactive-info-needed.yml
+++ b/.github/workflows/close-inactive-info-needed.yml
@@ -1,0 +1,41 @@
+name: Close inactive info-needed Issues
+
+on:
+  schedule:
+    - cron: "17 3 * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Log eligible Issues without changing them
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: close-inactive-info-needed
+  cancel-in-progress: false
+
+jobs:
+  close-inactive:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v11
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          only-issue-labels: info needed
+          stale-issue-label: info needed
+          days-before-issue-stale: -1
+          days-before-issue-close: 14
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          remove-issue-stale-when-updated: true
+          close-issue-reason: completed
+          close-issue-message: >-
+            This issue was automatically closed because the requested
+            information was not provided for 14 days. If you can provide
+            the missing details, please ask us to reopen it.
+          debug-only: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run }}
+          operations-per-run: 100


### PR DESCRIPTION
## Related issues

N/A

## Problem

The repository needs clearer Issue and pull request intake, a private maintainer contact path, and lightweight tools for maintaining incomplete or older Issues.

## Changes and scope

Adds Bug Report, Feature Request, and Question forms; disables blank Issues; adds the maintainer contact page and pull request template; closes inactive info-needed Issues after 14 days; and adds a manual batch reply and close workflow.

The test-only immediate-close workflow, Discussions, external community channels, Provider listings, and CHANGELOG.md are intentionally not included.

After merge, the first production run should be started manually in Dry Run mode. The current 23 info-needed Issues have been reviewed: 11 may close automatically and 12 may remain open with the label removed.

## Final checks

- [x] I reviewed and can explain every change
- [x] I reviewed any user-facing text changes in both English and Chinese
- [x] This pull request contains no API keys, authorization headers, private prompts, private code, or unreviewed sensitive logs.