### PR TITLE
docs(zh-cn): 修正命令面板快捷键显示不全并润色中文文档 / Fix incomplete command palette shortcut and polish Chinese docs

### DIFF
--- a/README.zh-cn.md
+++ b/README.zh-cn.md
@@ -21,14 +21,14 @@
   <img src="resources/screenshots/01-picker.png" alt="DeepSeek V4 Flash、Flash Vision Exp 和 Pro 出现在 Copilot Chat 模型选择器中，并展示思考深度菜单" width="800">
 </p>
 
-喜欢 DeepSeek 的性价比，但不想放弃 GitHub Copilot 的 Agent 模式、工具调用和成熟的交互体验？本扩展将 **DeepSeek V4 Flash、Pro 和 Flash Vision Exp** 直接接入 Copilot Chat 模型选择器，支持**原生视觉或视觉代理**、**思考模式**，并使用你自己的 API Key。
+喜欢 DeepSeek 的性价比，但不想放弃 GitHub Copilot 的 Agent 模式、工具调用和成熟的交互体验？本扩展将 **DeepSeek V4 Flash、Pro 和 Flash Vision Exp** 直接接入 Copilot Chat 模型选择器，支持 **原生视觉或视觉代理**、**思考模式**，并使用你自己的 API Key。
 
 ## 为什么选这个扩展？
 
 - **不是替换 Copilot，而是增强它。** 没有新的侧边栏，没有新的聊天界面需要学习。只是在你已经在用的模型选择器中多了一个选项。
 - **Agent 模式、工具调用、Instructions、MCP、Skills——全部正常运作。** Copilot 的完整能力栈，现在跑在 DeepSeek 上。
 - **两种图片处理方式。** Flash Vision Exp 会原生接收图片附件；Flash 和 Pro 则保留原有文本上下文，由可配置的视觉代理将图片转换为文字描述。
-- **需自行提供 API Key，直接向 DeepSeek 付费。** 你的 API Key，你的账单，你的速率限制。密钥存储在操作系统密钥链中，不会以明文形式写入磁盘。
+- **需自行提供 API Key，直接向 DeepSeek 付费。** 你的 API Key，你的账单，你的速率限制。密钥存储在系统密钥链中，不会以明文形式写入磁盘。
 
 ## 功能特性
 
@@ -71,7 +71,7 @@ API Key 存储在 VS Code 的 `SecretStorage` 中（macOS 钥匙串 / Windows �
 
 ### 前置条件
 
-- VS Code 1.116 及以上版本。本扩展依赖非公开的 Copilot Chat API，较新的 VS Code 版本可能存在兼容性问题——如遇到请[提交 Issue](https://github.com/Vizards/deepseek-v4-for-copilot/issues)。
+- VS Code 1.116 及以上版本。本扩展依赖非公开的 Copilot Chat API，在较新的 VS Code 版本上可能存在兼容性问题——如果遇到问题，请[提交 Issue](https://github.com/Vizards/deepseek-v4-for-copilot/issues)。
 - GitHub Copilot 订阅（Free / Pro / Enterprise——免费版即可使用）
 - DeepSeek API Key，从 [platform.deepseek.com](https://platform.deepseek.com) 获取；使用自定义 `deepseek-copilot.baseUrl` 时也可使用兼容的 provider token
 
@@ -84,10 +84,10 @@ API Key 存储在 VS Code 的 `SecretStorage` 中（macOS 钥匙串 / Windows �
 
 ### 使用步骤
 
-1. 通过命令面板（`Cmd+Shift+P`）运行 **DeepSeek: 设置 API Key**
+1. 通过命令面板（`Cmd/Ctrl + Shift + P`）运行 **DeepSeek: 设置 API Key**
 2. 粘贴你的 Key 或兼容的 provider token（官方 DeepSeek Key 通常以 `sk-` 开头）
 3. 打开 Copilot Chat，点击模型选择器，选择 **DeepSeek V4 Flash**、**DeepSeek V4 Pro** 或 **DeepSeek V4 Flash Vision Exp**
-4. 搞定——开始聊天
+4. 搞定！现在开始聊天吧。
 
 ## 模型
 

--- a/resources/walkthrough/show-models.nls.zh-cn.md
+++ b/resources/walkthrough/show-models.nls.zh-cn.md
@@ -1,3 +1,3 @@
 扩展激活后，DeepSeek 模型应立即出现在 Copilot 模型选择器中。如果尚未配置 API Key，模型会显示警告图标，直到你运行 `DeepSeek: 设置 API Key` 为止。
 
-如果没有立即看到，可能只是模型列表较长。在选取器中向下滚动，查找 DeepSeek V4 Flash、Pro 和 Flash Vision Exp。
+如果没有立即看到，可能只是模型列表较长。在模型选择器中向下滚动，查找 DeepSeek V4 Flash、Pro 和 Flash Vision Exp。


### PR DESCRIPTION
﻿中文 / Chinese

首先感谢这个项目的贡献，作为使用者我们从中受益很大。

这次提交主要针对我们在使用中文文档时发现的**快捷键显示不全**问题：

**1. 快捷键修正（本次主要发现）**
README.zh-cn.md「使用步骤」中命令面板快捷键仅写了 `Cmd+Shift+P`（macOS），Windows/Linux 用户无法直接使用。已改为跨平台写法 `Cmd/Ctrl + Shift + P`，与 `set-api-key.nls.zh-cn.md` 保持一致。

**2. 顺带润色项**
- **术语统一（密钥链）**：将「操作系统密钥链」统一为「系统密钥链」，与方案对比表一致，避免与「macOS 钥匙串 / Windows 凭据管理器 / Linux 密钥环」表述混淆。
- **语法通顺（前置条件）**：「较新的 VS Code 版本可能存在兼容性问题——如遇到请[提交 Issue]」改为「在较新的 VS Code 版本上可能存在兼容性问题——如果遇到问题，请[提交 Issue]」。
- **遣词更顺（完成提示）**：「搞定——开始聊天」改为「搞定！现在开始聊天吧。」。
- **排版统一（加粗空格）**：将「支持**原生视觉或视觉代理**、**思考模式**」统一为「支持 **原生视觉或视觉代理**、**思考模式**」，与同段落其它加粗一致。
- **术语统一（选取器）**：`show-models.nls.zh-cn.md` 中「在选取器中向下滚动」统一为「在模型选择器中向下滚动」。

如果还有其他问题，欢迎联系我们继续协助解决。

---

English

First of all, thanks for this project — as users we've benefited a lot from it.

This PR mainly addresses the **incomplete command palette shortcut** we found while using the Chinese docs:

**1. Shortcut fix (main finding)**
In `README.zh-cn.md` "Usage", the command palette shortcut was only written as `Cmd+Shift+P` (macOS), which is unusable for Windows/Linux users. Changed to the cross-platform form `Cmd/Ctrl + Shift + P`, consistent with `set-api-key.nls.zh-cn.md`.

**2. Incidental polish**
- **Terminology (keychain)**: unified "操作系统密钥链" to "系统密钥链", consistent with the comparison table, avoiding confusion with "macOS 钥匙串 / Windows 凭据管理器 / Linux 密钥环".
- **Grammar (prerequisites)**: "较新的 VS Code 版本可能存在兼容性问题——如遇到请[提交 Issue]" → "在较新的 VS Code 版本上可能存在兼容性问题——如果遇到问题，请[提交 Issue]".
- **Wording (finish prompt)**: "搞定——开始聊天" → "搞定！现在开始聊天吧。".
- **Typography (bold spacing)**: "支持**原生视觉或视觉代理**、**思考模式**" → "支持 **原生视觉或视觉代理**、**思考模式**", consistent with other bold text in the same paragraph.
- **Terminology (picker)**: in `show-models.nls.zh-cn.md`, "在选取器中向下滚动" → "在模型选择器中向下滚动".

If there are any other issues, feel free to reach out and we'll help continue.