### PR TITLE
fix(vision): stabilize proxied tool image descriptions

### DIFF
--- a/src/provider/replay/markers.ts
+++ b/src/provider/replay/markers.ts
@@ -14,6 +14,7 @@ import type {
 	ReplayMarkerMetadata,
 	ReplayMarkerParseResult,
 	ReplayMarkerPayloadFormat,
+	ToolVisionReplayEntry,
 	VisionMarkerTextIgnoredReason,
 } from './types';
 
@@ -46,7 +47,7 @@ function parseReplayMarkerPart(part: unknown): ReplayMarkerParseResult | undefin
 }
 
 export function hasReplayMarkerMetadata(metadata: ReplayMarkerMetadata): boolean {
-	return Boolean(metadata.visionText || metadata.reasoningText);
+	return Boolean(metadata.visionText || metadata.reasoningText || metadata.toolVision?.length);
 }
 
 export function createReplayMarkerPart(
@@ -54,6 +55,7 @@ export function createReplayMarkerPart(
 ): vscode.LanguageModelDataPart {
 	const payload = encodeReplayMarkerJson({
 		...createVisionMarkerPayload(metadata.visionText),
+		...(metadata.toolVision?.length ? { toolVision: { results: metadata.toolVision } } : {}),
 		...createReasoningMarkerPayload(metadata.reasoningText),
 	});
 	return new vscode.LanguageModelDataPart(
@@ -102,13 +104,16 @@ export function parseReplayMarkerData(data: Uint8Array): ReplayMarkerParseResult
 		}
 
 		const vision = parseVisionMarkerMetadata(value);
+		const toolVision = parseToolVisionMarkerMetadata(value);
 		const reasoning = parseReasoningMarkerMetadata(value);
+		const hasMetadata = vision.visionText || toolVision?.length || reasoning.reasoningText;
 		return {
 			valid: true,
 			segmentId: segmentId.value,
 			...vision,
+			...(toolVision ? { toolVision } : {}),
 			...reasoning,
-			legacySegmentOnly: Boolean(segmentId.value && !vision.visionText && !reasoning.reasoningText),
+			legacySegmentOnly: Boolean(segmentId.value && !hasMetadata),
 			payloadFormat: decodedPayload.format,
 		};
 	} catch {
@@ -158,6 +163,26 @@ function parseVisionMarkerMetadata(value: object): {
 	}
 
 	return { visionText: text };
+}
+
+function parseToolVisionMarkerMetadata(value: object): ToolVisionReplayEntry[] | undefined {
+	const results = (value as { toolVision?: { results?: unknown } }).toolVision?.results;
+	const entries = Array.isArray(results) ? results.filter(isToolVisionReplayEntry) : [];
+	return entries.length > 0 ? entries : undefined;
+}
+
+function isToolVisionReplayEntry(value: unknown): value is ToolVisionReplayEntry {
+	const entry = value as Partial<ToolVisionReplayEntry> | null;
+	return Boolean(
+		entry &&
+		typeof entry.callId === 'string' &&
+		entry.callId.length > 0 &&
+		typeof entry.resolvedContent === 'string' &&
+		entry.resolvedContent.length > 0 &&
+		typeof entry.imageParts === 'number' &&
+		Number.isSafeInteger(entry.imageParts) &&
+		entry.imageParts > 0,
+	);
 }
 
 function createReasoningMarkerPayload(reasoningText: string | undefined): object {

--- a/src/provider/replay/types.ts
+++ b/src/provider/replay/types.ts
@@ -3,6 +3,7 @@ export interface ReplayMarkerParseResult {
 	segmentId?: string;
 	visionText?: string;
 	visionTextIgnoredReason?: VisionMarkerTextIgnoredReason;
+	toolVision?: ToolVisionReplayEntry[];
 	reasoningText?: string;
 	reasoningTextIgnoredReason?: ReasoningMarkerTextIgnoredReason;
 	legacySegmentOnly?: boolean;
@@ -22,6 +23,12 @@ export type VisionMarkerTextIgnoredReason =
 	| 'vision-text-not-string'
 	| 'vision-text-empty';
 
+export interface ToolVisionReplayEntry {
+	callId: string;
+	resolvedContent: string;
+	imageParts: number;
+}
+
 export type ReasoningMarkerTextIgnoredReason =
 	| 'reasoning-not-object'
 	| 'reasoning-text-not-string'
@@ -29,5 +36,6 @@ export type ReasoningMarkerTextIgnoredReason =
 
 export interface ReplayMarkerMetadata {
 	visionText?: string;
+	toolVision?: readonly ToolVisionReplayEntry[];
 	reasoningText?: string;
 }

--- a/src/provider/vision/resolve.ts
+++ b/src/provider/vision/resolve.ts
@@ -82,7 +82,7 @@ export async function resolveImageMessages(
 		stats.input.droppedImageParts += imageParts.length;
 		result.push(createResolvedMessage(message, nonImageParts));
 	}
-	const toolResolution = await resolveToolResultImages(result, session);
+	const toolResolution = await resolveToolResultImages(result, session, stats);
 	const toolVision = toolResolution.replayEntries;
 	const sessionMetadata = session.getMetadata();
 

--- a/src/provider/vision/resolve.ts
+++ b/src/provider/vision/resolve.ts
@@ -22,7 +22,14 @@ export async function resolveImageMessages(
 	token: vscode.CancellationToken,
 	getDescriber: () => Promise<VisionDescriber | undefined>,
 ): Promise<VisionResolutionResult> {
-	if (summary.inputImageParts + summary.toolResultImageParts === 0) {
+	if (
+		summary.inputImageParts + summary.toolResultImageParts === 0 &&
+		!messages.some(
+			(message) =>
+				message.role === vscode.LanguageModelChatMessageRole.Assistant &&
+				Boolean(parseFirstReplayMarker(message)?.toolVision?.length),
+		)
+	) {
 		return { messages, stats, replayMarkerMetadata: {} };
 	}
 	const session = createVisionDescriptionSession(stats, token, getDescriber);
@@ -75,13 +82,14 @@ export async function resolveImageMessages(
 		stats.input.droppedImageParts += imageParts.length;
 		result.push(createResolvedMessage(message, nonImageParts));
 	}
-	const resolvedMessages = await resolveToolResultImages(result, session);
+	const toolResolution = await resolveToolResultImages(result, session);
+	const toolVision = toolResolution.replayEntries;
 	const sessionMetadata = session.getMetadata();
 
 	return {
-		messages: resolvedMessages,
+		messages: toolResolution.messages,
 		stats,
-		replayMarkerMetadata: markerVisionText ? { visionText: markerVisionText } : {},
+		replayMarkerMetadata: { visionText: markerVisionText, toolVision },
 		...sessionMetadata,
 	};
 }

--- a/src/provider/vision/tool.ts
+++ b/src/provider/vision/tool.ts
@@ -88,8 +88,11 @@ async function resolveToolResultPart(
 	const imagePartCount = normalized.parts.filter((item) => item.type === 'image').length;
 	const replayEntry = replayIndex
 		.get(normalized.callId)
-		?.find(([markerIndex]) => markerIndex > messageIndex)?.[1];
-	if (replayEntry && (imagePartCount === 0 || imagePartCount === replayEntry.imageParts)) {
+		?.find(
+			([markerIndex, entry]) =>
+				markerIndex > messageIndex && (imagePartCount === 0 || imagePartCount === entry.imageParts),
+		)?.[1];
+	if (replayEntry) {
 		stats.replayedImageMessages += 1;
 		stats.tool.droppedImageParts += imagePartCount;
 		return new vscode.LanguageModelToolResultPart(normalized.callId, [

--- a/src/provider/vision/tool.ts
+++ b/src/provider/vision/tool.ts
@@ -1,18 +1,33 @@
 import vscode from 'vscode';
 import { normalizeToolResult } from './normalize';
+import { parseFirstReplayMarker } from '../replay';
+import type { ToolVisionReplayEntry } from '../replay/types';
 import type { VisionDescriptionSession } from './description';
 
 type ChatMessageContentPart = vscode.LanguageModelChatRequestMessage['content'][number];
+type ToolVisionReplayIndex = Map<string, [number, ToolVisionReplayEntry][]>;
 
 /** Replace actual tool-result image data parts with proxy descriptions in place. */
 export async function resolveToolResultImages(
 	messages: readonly vscode.LanguageModelChatRequestMessage[],
 	session: VisionDescriptionSession,
-): Promise<readonly vscode.LanguageModelChatRequestMessage[]> {
+) {
+	const replayIndex: ToolVisionReplayIndex = new Map();
+	for (const [messageIndex, message] of messages.entries()) {
+		if (message.role !== vscode.LanguageModelChatMessageRole.Assistant) {
+			continue;
+		}
+		for (const entry of parseFirstReplayMarker(message)?.toolVision ?? []) {
+			const entries = replayIndex.get(entry.callId) ?? [];
+			entries.push([messageIndex, entry]);
+			replayIndex.set(entry.callId, entries);
+		}
+	}
+	const replayEntries: ToolVisionReplayEntry[] = [];
 	let messagesChanged = false;
 	const resolvedMessages: vscode.LanguageModelChatRequestMessage[] = [];
 
-	for (const message of messages) {
+	for (const [messageIndex, message] of messages.entries()) {
 		if (message.role !== vscode.LanguageModelChatMessageRole.User) {
 			resolvedMessages.push(message);
 			continue;
@@ -26,7 +41,13 @@ export async function resolveToolResultImages(
 				continue;
 			}
 
-			const resolvedPart = await resolveToolResultPart(part, session);
+			const resolvedPart = await resolveToolResultPart(
+				part,
+				messageIndex,
+				replayIndex,
+				session,
+				replayEntries,
+			);
 			content.push(resolvedPart);
 			if (resolvedPart !== part) {
 				messageChanged = true;
@@ -46,32 +67,51 @@ export async function resolveToolResultImages(
 		} as vscode.LanguageModelChatRequestMessage);
 	}
 
-	return messagesChanged ? resolvedMessages : messages;
+	return {
+		messages: messagesChanged ? resolvedMessages : messages,
+		replayEntries,
+	};
 }
 
 async function resolveToolResultPart(
 	part: vscode.LanguageModelToolResultPart,
+	messageIndex: number,
+	replayIndex: ToolVisionReplayIndex,
 	session: VisionDescriptionSession,
-): Promise<vscode.LanguageModelToolResultPart> {
+	replayEntries: ToolVisionReplayEntry[],
+) {
 	const normalized = normalizeToolResult(part);
-	if (!normalized.parts.some((item) => item.type === 'image')) {
+	const imagePartCount = normalized.parts.filter((item) => item.type === 'image').length;
+	const replayEntry = replayIndex
+		.get(normalized.callId)
+		?.find(([markerIndex]) => markerIndex > messageIndex)?.[1];
+	if (replayEntry && (imagePartCount === 0 || imagePartCount === replayEntry.imageParts)) {
+		return new vscode.LanguageModelToolResultPart(normalized.callId, [
+			new vscode.LanguageModelTextPart(replayEntry.resolvedContent),
+		]);
+	}
+	if (imagePartCount === 0) {
 		return part;
 	}
 
 	const content: vscode.LanguageModelToolResultPart['content'] = [];
+	let resolvedContent = '';
 	for (const item of normalized.parts) {
 		if (item.type === 'text') {
 			content.push(new vscode.LanguageModelTextPart(item.text));
+			resolvedContent += item.text;
 		} else if (item.type === 'image') {
 			const description = await session.describe(
 				[{ mimeType: item.mimeType, data: item.data }],
 				'tool',
 			);
 			content.push(new vscode.LanguageModelTextPart(description));
+			resolvedContent += description;
 		} else {
 			content.push(item.value);
 		}
 	}
 
+	replayEntries.push({ callId: normalized.callId, resolvedContent, imageParts: imagePartCount });
 	return new vscode.LanguageModelToolResultPart(normalized.callId, content);
 }

--- a/src/provider/vision/tool.ts
+++ b/src/provider/vision/tool.ts
@@ -3,6 +3,7 @@ import { normalizeToolResult } from './normalize';
 import { parseFirstReplayMarker } from '../replay';
 import type { ToolVisionReplayEntry } from '../replay/types';
 import type { VisionDescriptionSession } from './description';
+import type { VisionResolutionStats } from './types';
 
 type ChatMessageContentPart = vscode.LanguageModelChatRequestMessage['content'][number];
 type ToolVisionReplayIndex = Map<string, [number, ToolVisionReplayEntry][]>;
@@ -11,6 +12,7 @@ type ToolVisionReplayIndex = Map<string, [number, ToolVisionReplayEntry][]>;
 export async function resolveToolResultImages(
 	messages: readonly vscode.LanguageModelChatRequestMessage[],
 	session: VisionDescriptionSession,
+	stats: VisionResolutionStats,
 ) {
 	const replayIndex: ToolVisionReplayIndex = new Map();
 	for (const [messageIndex, message] of messages.entries()) {
@@ -46,6 +48,7 @@ export async function resolveToolResultImages(
 				messageIndex,
 				replayIndex,
 				session,
+				stats,
 				replayEntries,
 			);
 			content.push(resolvedPart);
@@ -78,6 +81,7 @@ async function resolveToolResultPart(
 	messageIndex: number,
 	replayIndex: ToolVisionReplayIndex,
 	session: VisionDescriptionSession,
+	stats: VisionResolutionStats,
 	replayEntries: ToolVisionReplayEntry[],
 ) {
 	const normalized = normalizeToolResult(part);
@@ -86,6 +90,8 @@ async function resolveToolResultPart(
 		.get(normalized.callId)
 		?.find(([markerIndex]) => markerIndex > messageIndex)?.[1];
 	if (replayEntry && (imagePartCount === 0 || imagePartCount === replayEntry.imageParts)) {
+		stats.replayedImageMessages += 1;
+		stats.tool.droppedImageParts += imagePartCount;
 		return new vscode.LanguageModelToolResultPart(normalized.callId, [
 			new vscode.LanguageModelTextPart(replayEntry.resolvedContent),
 		]);


### PR DESCRIPTION
## Stack

Depends on #260.

This PR is intentionally based on `fix/tool-result-image-routing`, so its diff contains only the tool-vision description replay layer. Review and merge #260 first; this PR can then be retargeted to `main`.

## Problem

The parent PR routes Flash/Pro tool-result images through Vision Proxy, but VS Code retains the actual image DataPart across multiple internal model requests in the same user turn. Resolving it again on every request causes:

- repeated proxy latency and cost;
- description drift within one A -> B -> C tool chain;
- an unstable DeepSeek prefix before later tool calls.

On the next independent user turn, VS Code replaces the historical tool image with a fixed placeholder. Forwarding that placeholder changes the same historical tool message again and breaks the cached prefix from that point.

## Changes

- Store the exact resolved tool-result content in the existing assistant replay marker.
- Bind replay data back to the corresponding tool result by `callId` and image-part count.
- Reuse the exact content for repeated current DataParts without another proxy call.
- Restore the exact content when VS Code later supplies only the historical placeholder.
- Validate replay marker payloads before use.

This does not persist or cache image bytes, hydrate resource URIs, infer images from paths, or add path/file fallback behavior.

## Validation

Static checks:

- `npm run compile`
- `npm run lint`
- `npm run format:check`
- `git diff --check`

Manual VS Code Stable Copilot Chat Agent validation:

- Flash and Pro each reduced the A -> B -> C chain from three proxy requests to one.
- The final A tool content remained byte-identical after A, after B, after C, and on the next user turn.
- On the next user turn, provider ingress contained the VS Code historical placeholder, while the final DeepSeek request still contained the original description and made no proxy request.
- Same-turn cache hit rates extended from 91% to 98% to 99% on Flash, and from 91% to 95% to 96% on Pro.
- A separate VS Code `renderMermaidDiagram` tool-schema injection still affects the whole-request next-turn cache rate; message-level comparison confirms the tool image message itself no longer changes.

No automated tests are added in this stack layer; the behavior was validated through the normal Copilot Chat provider boundary.
